### PR TITLE
feat: Add staff/moderator markers [BB-4736] [TNL-7793] [BD-38]

### DIFF
--- a/src/discussions/comments/reply/Reply.jsx
+++ b/src/discussions/comments/reply/Reply.jsx
@@ -21,7 +21,7 @@ function ReplyHeader({ reply, intl }) {
         <div className="status small">
           <a href="#nowhere">
             <h1 className="font-weight-normal text-info-300 mr-1 small">
-              {reply.author}
+              {reply.author} {reply.authorLabel ? `(${reply.authorLabel})` : '' }
             </h1>
           </a>
           <h2 className="font-weight-normal small text-gray-500" title={reply.createdAt}>

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -74,6 +74,7 @@ function PostHeader({
                 {
                   author: post.author,
                   time: timeago.format(post.createdAt, intl.locale),
+                  authorLabel: post.authorLabel ? `(${post.authorLabel})` : '',
                 },
               )}
             </span>

--- a/src/discussions/posts/post/messages.js
+++ b/src/discussions/posts/post/messages.js
@@ -7,7 +7,7 @@ const messages = defineMessages({
   },
   postedOn: {
     id: 'discussions.post.posted-on',
-    defaultMessage: 'Posted {time} by {author}',
+    defaultMessage: 'Posted {time} by {author} {authorLabel}',
   },
   contentReported: {
     id: 'discussions.post.content-reported',


### PR DESCRIPTION
## Description

This PR adds a user's role information e.g "Staff" next to the user's name in the UI.

## Supporting Information

- [BB-4736](https://tasks.opencraft.com/browse/BB-4736)
- [TNL-7793](https://openedx.atlassian.net/browse/TNL-7793)

## Testing Instructions

- Add some new posts via the LMS discussion forum here http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/ 
- Checkout to this branch `tinumide/add_staff_moderator_markers` in the `frontend-app-discussions` repository
- Start the app and browse the url http://localhost:2002/discussions/course-v1:edX+DemoX+Demo_Course/topics to see the posts
