### PR TITLE
feat: add cohort selection [BD-38] [TNL-8713] [BB-4926]

### DIFF
--- a/src/discussions/cohorts/data/__factories__/cohorts.factory.js
+++ b/src/discussions/cohorts/data/__factories__/cohorts.factory.js
@@ -1,0 +1,8 @@
+import { Factory } from 'rosie';
+
+Factory.define('cohort')
+  .sequence('id', (idx) => `cohort-${idx}`)
+  .sequence('name', (idx) => `cohort ${idx}`)
+  .sequence('group_id', (idx) => `group-${idx}`)
+  .attr('user_count', 0)
+  .attr('assignment_type', 'manual');

--- a/src/discussions/cohorts/data/__factories__/index.js
+++ b/src/discussions/cohorts/data/__factories__/index.js
@@ -1,0 +1,1 @@
+import './cohorts.factory';

--- a/src/discussions/cohorts/data/api.js
+++ b/src/discussions/cohorts/data/api.js
@@ -1,0 +1,19 @@
+/* eslint-disable import/prefer-default-export */
+import { ensureConfig, getConfig, snakeCaseObject } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
+ensureConfig([
+  'LMS_BASE_URL',
+], 'Comments API service');
+
+const apiBaseUrl = getConfig().LMS_BASE_URL;
+
+export const getCohortsApiUrl = courseId => `${apiBaseUrl}/api/cohorts/v1/courses/${courseId}/cohorts/`;
+
+export async function getCourseCohorts(courseId) {
+  const params = snakeCaseObject({ courseId });
+
+  const { data } = await getAuthenticatedHttpClient()
+    .get(getCohortsApiUrl(courseId), { params });
+  return data;
+}

--- a/src/discussions/cohorts/data/index.js
+++ b/src/discussions/cohorts/data/index.js
@@ -1,0 +1,1 @@
+export * from './slices';

--- a/src/discussions/cohorts/data/redux.test.js
+++ b/src/discussions/cohorts/data/redux.test.js
@@ -1,0 +1,73 @@
+import MockAdapter from 'axios-mock-adapter';
+import { Factory } from 'rosie';
+
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { initializeMockApp } from '@edx/frontend-platform/testing';
+
+import { initializeStore } from '../../../store';
+import { executeThunk } from '../../../test-utils';
+import { getCohortsApiUrl } from './api';
+import { fetchCourseCohorts } from './thunks';
+
+import './__factories__';
+
+const courseId = 'course-v1:edX+TestX+Test_Course';
+const courseId2 = 'course-v1:edX+TestX+Test_Course2';
+let axiosMock;
+let store;
+
+describe('Cohorts data layer tests', () => {
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    Factory.resetAll();
+    store = initializeStore();
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  it('successfully fetch course cohorts', async () => {
+    axiosMock.onGet(getCohortsApiUrl(courseId))
+      .reply(200, Factory.buildList('cohort', 3));
+
+    await executeThunk(
+      fetchCourseCohorts(courseId),
+      store.dispatch,
+      store.getState,
+    );
+
+    expect(store.getState().cohorts.cohorts.map(cohort => cohort.id))
+      .toEqual(['cohort-1', 'cohort-2', 'cohort-3']);
+  });
+
+  it('failed fetch different course cohorts', async () => {
+    axiosMock.onGet(getCohortsApiUrl(courseId))
+      .reply(200, Factory.buildList('cohort', 3));
+    axiosMock.onGet(getCohortsApiUrl(courseId2))
+      .reply(404);
+
+    await executeThunk(
+      fetchCourseCohorts(courseId),
+      store.dispatch,
+      store.getState,
+    );
+    await executeThunk(
+      fetchCourseCohorts(courseId2),
+      store.dispatch,
+      store.getState,
+    );
+
+    // cohorts shouldn't contain outdated data
+    expect(store.getState().cohorts.cohorts).toEqual([]);
+  });
+});

--- a/src/discussions/cohorts/data/selectors.js
+++ b/src/discussions/cohorts/data/selectors.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/prefer-default-export */
+
+export const selectCourseCohorts = state => state.cohorts.cohorts;

--- a/src/discussions/cohorts/data/slices.js
+++ b/src/discussions/cohorts/data/slices.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-param-reassign,import/prefer-default-export */
+import { createSlice } from '@reduxjs/toolkit';
+
+import { RequestStatus } from '../../../data/constants';
+
+const cohortsSlice = createSlice({
+  name: 'cohorts',
+  initialState: {
+    status: RequestStatus.IN_PROGRESS,
+    cohorts: [],
+  },
+  reducers: {
+    fetchCohortsRequest: (state) => {
+      state.status = RequestStatus.IN_PROGRESS;
+      state.cohorts = [];
+    },
+    fetchCohortsSuccess: (state, { payload }) => {
+      state.status = RequestStatus.SUCCESSFUL;
+      state.cohorts = payload;
+    },
+    fetchCohortsFailed: (state) => {
+      state.status = RequestStatus.FAILED;
+    },
+  },
+});
+
+export const {
+  fetchCohortsRequest,
+  fetchCohortsSuccess,
+  fetchCohortsFailed,
+} = cohortsSlice.actions;
+
+export const cohortsReducer = cohortsSlice.reducer;

--- a/src/discussions/cohorts/data/thunks.js
+++ b/src/discussions/cohorts/data/thunks.js
@@ -1,0 +1,25 @@
+/* eslint-disable import/prefer-default-export */
+import { camelCaseObject } from '@edx/frontend-platform';
+import { logError } from '@edx/frontend-platform/logging';
+
+import {
+  getCourseCohorts,
+} from './api';
+import {
+  fetchCohortsFailed,
+  fetchCohortsRequest,
+  fetchCohortsSuccess,
+} from './slices';
+
+export function fetchCourseCohorts(courseId) {
+  return async (dispatch) => {
+    try {
+      dispatch(fetchCohortsRequest());
+      const data = await getCourseCohorts(courseId);
+      dispatch(fetchCohortsSuccess(camelCaseObject(data)));
+    } catch (error) {
+      dispatch(fetchCohortsFailed());
+      logError(error);
+    }
+  };
+}

--- a/src/discussions/posts/data/api.js
+++ b/src/discussions/posts/data/api.js
@@ -79,7 +79,7 @@ export async function getThread(threadId) {
  * @param {boolean} following Follow the thread after creating
  * @returns {Promise<{}>}
  */
-export async function postThread(courseId, topicId, type, title, content, following = false) {
+export async function postThread(courseId, topicId, type, title, content, following = false, cohort) {
   const postData = snakeCaseObject({
     courseId,
     topicId,
@@ -87,6 +87,7 @@ export async function postThread(courseId, topicId, type, title, content, follow
     title,
     raw_body: content,
     following,
+    groupId: cohort,
   });
 
   const { data } = await getAuthenticatedHttpClient().post(threadsApiUrl, postData);

--- a/src/discussions/posts/data/redux.test.js
+++ b/src/discussions/posts/data/redux.test.js
@@ -132,6 +132,25 @@ describe('Threads/Posts data layer tests', () => {
       .toEqual(topicId);
   });
 
+  test('successfully handles thread creation for topic that has not been preloaded', async () => {
+    const topicId = 'test-topic';
+    const title = 'A Test Thread';
+    const content = 'Some test content';
+
+    axiosMock.onPost(`${threadsApiUrl}`)
+      .reply(200, Factory.build('thread', {
+        course_id: courseId, topic_id: topicId, title, raw_body: content, rendered_body: content,
+      }));
+
+    expect(store.getState().threads.threadsInTopic[topicId])
+      .toEqual(undefined);
+
+    await executeThunk(createNewThread(courseId, topicId, 'discussion', title, content), store.dispatch, store.getState);
+
+    expect(store.getState().threads.threadsInTopic[topicId])
+      .toEqual(['thread-1']);
+  });
+
   test('successfully handles thread updates', async () => {
     const threadId = 'thread-2';
     axiosMock.onGet(threadsApiUrl)

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -84,7 +84,10 @@ const threadsSlice = createSlice({
     postThreadSuccess: (state, { payload }) => {
       state.postStatus = RequestStatus.SUCCESSFUL;
       state.threadsById[payload.id] = payload;
-      state.threadsInTopic[payload.topicId].push(payload.id);
+      state.threadsInTopic[payload.topicId] = [
+        ...(state.threadsInTopic[payload.topicId] || []),
+        payload.id,
+      ];
       // Temporarily add it to the top of the list so it's visible
       state.pages[0] = [payload.id].concat(state.pages[0] || []);
       state.avatars = { ...state.avatars, ...payload.avatars };

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -171,6 +171,7 @@ export function createNewThread({
   title,
   content,
   following = false,
+  cohort,
 }) {
   return async (dispatch) => {
     try {
@@ -181,8 +182,9 @@ export function createNewThread({
         title,
         content,
         following,
+        cohort,
       }));
-      const data = await postThread(courseId, topicId, type, title, content, following);
+      const data = await postThread(courseId, topicId, type, title, content, following, cohort);
       dispatch(postThreadSuccess(camelCaseObject(data)));
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {

--- a/src/discussions/posts/post-editor/messages.js
+++ b/src/discussions/posts/post-editor/messages.js
@@ -45,6 +45,14 @@ const messages = defineMessages({
     id: 'discussions.post.editor.topicAreaDescription',
     defaultMessage: 'Add your post to a relevant topic to help others find it.',
   },
+  cohortVisibility: {
+    id: 'discussions.post.editor.cohortVisibility',
+    defaultMessage: 'Cohort visibility',
+  },
+  cohortVisibilityAllLearners: {
+    id: 'discussions.post.editor.cohortVisibilityAllLearners',
+    defaultMessage: 'All learners',
+  },
   postTitle: {
     id: 'discussions.post.editor.title',
     defaultMessage: 'Post title',

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import { cohortsReducer } from './discussions/cohorts/data';
 import { commentsReducer } from './discussions/comments/data';
 import { threadsReducer } from './discussions/posts/data';
 import { topicsReducer } from './discussions/topics/data';
@@ -10,6 +11,7 @@ export function initializeStore(preloadedState = undefined) {
       topics: topicsReducer,
       threads: threadsReducer,
       comments: commentsReducer,
+      cohorts: cohortsReducer,
     },
     preloadedState,
   });


### PR DESCRIPTION
## Description
Add a field to post editor, which allows to select from course's cohorts.
"All learners" option is always available, and stands for no cohort.
![screenshot](https://user-images.githubusercontent.com/30300520/137417787-a9336b33-e832-4516-89bb-06dc29370a69.png)

## Supporting information
[TNL-8713](https://openedx.atlassian.net/browse/TNL-8713)

## Testing steps
As discussions administrator:
- Create a post with a "All learners" cohort (i.e. either don't select anything under "Cohort visibility" field, or select "All Learners" option)
- Create a post with a cohort
- Check that can't edit cohort for an existing post

As normal user:
- Check that "Cohort visibility" field is not visible when trying to create or edit an existing post