### PR TITLE
fix: topic counts were not included in normalised data [BD-38] [TNL-9403]

### DIFF
--- a/src/discussions/topics/data/thunks.js
+++ b/src/discussions/topics/data/thunks.js
@@ -11,13 +11,13 @@ function normaliseTopics(data) {
   const categoryIds = [];
   data.coursewareTopics.forEach(category => {
     topicsInCategory[category.name] = category.children.map(topic => {
-      topics[topic.id] = { id: topic.id, name: topic.name, categoryId: category.name };
+      topics[topic.id] = { ...topic, categoryId: category.name };
       return topic.id;
     });
     categoryIds.push(category.name);
   });
   const nonCoursewareIds = data.nonCoursewareTopics.map(topic => {
-    topics[topic.id] = { id: topic.id, name: topic.name };
+    topics[topic.id] = topic;
     return topic.id;
   });
   return {

--- a/src/discussions/topics/topic-group/topic/Topic.jsx
+++ b/src/discussions/topics/topic-group/topic/Topic.jsx
@@ -21,12 +21,12 @@ function Topic({ topic }) {
     {
       key: 'discussions',
       icon: PostIcon,
-      count: topic?.threadCounts?.discussions || 0,
+      count: topic.threadCounts?.discussion || 0,
     },
     {
       key: 'questions',
       icon: Help,
-      count: topic?.threadCounts?.questions || 0,
+      count: topic.threadCounts?.question || 0,
     },
   ];
   return (


### PR DESCRIPTION
The count of questions and discussions was not being passed correctly till the UI from the API response. This fixes the issue making topic counts available in the UI. 