### PR TITLE
feat: Enhance moderation features with deleted content handling

### DIFF
--- a/src/discussions/common/ActionsDropdown.jsx
+++ b/src/discussions/common/ActionsDropdown.jsx
@@ -12,7 +12,6 @@ import { useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { logError } from '@edx/frontend-platform/logging';
 
-import { ContentActions } from '../../data/constants';
 import { selectIsPostingEnabled, selectUserHasModerationPrivileges } from '../data/selectors';
 import messages from '../messages';
 import { useActions } from '../utils';
@@ -73,7 +72,11 @@ const ActionsDropdown = ({
       as={Button}
       variant="tertiary"
       size="inline"
+      disabled={action.disabled}
       onClick={() => {
+        if (action.disabled) {
+          return;
+        }
         if (action.hasSubmenu) {
           setActiveSubmenu(action.id);
         } else {
@@ -161,7 +164,7 @@ const ActionsDropdown = ({
       ) : (
         actions.map(action => (
           <React.Fragment key={action.id}>
-            {(action.id === 'ban' || action.action === ContentActions.DELETE) && <Dropdown.Divider />}
+            {(action.id === 'ban' || action.id === 'delete') && <Dropdown.Divider />}
             {action.hasSubmenu ? (
               renderMenuItem(action)
             ) : (

--- a/src/discussions/common/ActionsDropdown.test.jsx
+++ b/src/discussions/common/ActionsDropdown.test.jsx
@@ -252,6 +252,59 @@ describe('ActionsDropdown', () => {
     await waitFor(() => expect(screen.queryByText('Copy link')).not.toBeInTheDocument());
   });
 
+  it('shows deleted content actions as disabled except copy link and restore', async () => {
+    const deletedDiscussion = buildTestContent({
+      editable_fields: ['copy_link', 'delete', 'raw_body'],
+      is_deleted: true,
+      can_delete: true,
+    }).discussion;
+
+    await mockThreadAndComment(deletedDiscussion);
+    renderComponent({ ...camelCaseObject(deletedDiscussion) });
+
+    const openButton = await findOpenActionsDropdownButton();
+    await act(async () => {
+      fireEvent.click(openButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('copy-link')).toBeInTheDocument();
+      expect(screen.queryByTestId('restore')).toBeInTheDocument();
+      expect(screen.queryByTestId('copy-link')).not.toBeDisabled();
+      expect(screen.queryByTestId('restore')).not.toBeDisabled();
+      expect(screen.queryByTestId('edit')).toBeInTheDocument();
+      expect(screen.queryByTestId('edit')).toBeDisabled();
+      expect(screen.queryByTestId('delete-post')).toBeInTheDocument();
+      expect(screen.queryByTestId('delete-post')).toBeDisabled();
+    });
+  });
+
+  it('shows deleted comment actions as disabled except restore', async () => {
+    const deletedComment = buildTestContent({
+      editable_fields: ['delete', 'raw_body'],
+      is_deleted: true,
+      can_delete: true,
+    }).comment;
+
+    await mockThreadAndComment(deletedComment);
+    renderComponent({ ...camelCaseObject(deletedComment) });
+
+    const openButton = await findOpenActionsDropdownButton();
+    await act(async () => {
+      fireEvent.click(openButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('restore')).toBeInTheDocument();
+      expect(screen.queryByTestId('restore')).not.toBeDisabled();
+      expect(screen.queryByTestId('copy-link')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('edit')).toBeInTheDocument();
+      expect(screen.queryByTestId('edit')).toBeDisabled();
+      expect(screen.queryByTestId('delete-post')).toBeInTheDocument();
+      expect(screen.queryByTestId('delete-post')).toBeDisabled();
+    });
+  });
+
   it('should close the dropdown when pressing escape', async () => {
     const discussionObject = buildTestContent({ editable_fields: ['copy_link'] }).discussion;
     await mockThreadAndComment(discussionObject);

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -25,6 +25,8 @@ const AuthorLabel = ({
   postCreatedAt = null,
   authorToolTip = false,
   postOrComment = false,
+  singleLine = false,
+  roleBeforeTimestamp = false,
   postData = null, // Thread or comment data from API containing is_new_learner field
 }) => {
   timeago.register('time-locale', timeLocale);
@@ -233,6 +235,20 @@ const AuthorLabel = ({
     </span>
   );
 
+  if (singleLine) {
+    return (
+      <div className={className}>
+        <div className={classNames('d-flex align-items-center flex-nowrap', labelColor)}>
+          {showUserNameAsLink ? learnerPostsLink : authorName}
+          {roleBeforeTimestamp && roleContents}
+          {timestamp}
+          {!roleBeforeTimestamp && roleContents}
+          {bannedIndicator}
+        </div>
+      </div>
+    );
+  }
+
   return showUserNameAsLink ? (
     <div className={`${className} flex-wrap`}>
       <div className="d-flex flex-column w-100">
@@ -273,6 +289,8 @@ AuthorLabel.propTypes = {
   postCreatedAt: PropTypes.string,
   authorToolTip: PropTypes.bool,
   postOrComment: PropTypes.bool,
+  singleLine: PropTypes.bool,
+  roleBeforeTimestamp: PropTypes.bool,
   postData: PropTypes.shape({
     is_new_learner: PropTypes.bool,
     is_regular_learner: PropTypes.bool,
@@ -288,6 +306,8 @@ AuthorLabel.defaultProps = {
   postCreatedAt: null,
   authorToolTip: false,
   postOrComment: false,
+  singleLine: false,
+  roleBeforeTimestamp: false,
   postData: null,
 };
 

--- a/src/discussions/common/AuthorLabel.test.jsx
+++ b/src/discussions/common/AuthorLabel.test.jsx
@@ -250,6 +250,33 @@ describe('Author label', () => {
     });
   });
 
+  describe('Single-line ordering', () => {
+    it('renders role before age when roleBeforeTimestamp is true', () => {
+      render(
+        <IntlProvider locale="en">
+          <AppProvider store={store}>
+            <DiscussionContext.Provider value={{ courseId, enableInContextSidebar: false }}>
+              <AuthorLabel
+                author="staff_user"
+                authorLabel="Staff"
+                postCreatedAt="2026-03-06T00:00:00.000Z"
+                singleLine
+                roleBeforeTimestamp
+                alert
+              />
+            </DiscussionContext.Provider>
+          </AppProvider>
+        </IntlProvider>,
+      );
+
+      const roleLabel = screen.getByText('Staff');
+      const timestamp = document.querySelector('.post-summary-timestamp');
+
+      expect(timestamp).toBeInTheDocument();
+      expect(roleLabel.compareDocumentPosition(timestamp)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+  });
+
   describe('Null author handling', () => {
     it('should display "[Deleted User]" when author is null', () => {
       renderComponent(null, null, false, '');

--- a/src/discussions/common/DeletedByBanner.jsx
+++ b/src/discussions/common/DeletedByBanner.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Alert } from '@openedx/paragon';
+import { DeleteOutline } from '@openedx/paragon/icons';
+
+import { AvatarOutlineAndLabelColors } from '../../data/constants';
+import AuthorLabel from './AuthorLabel';
+
+const DeletedByBanner = ({
+  deletedBy,
+  deletedByLabel,
+  message,
+  postData,
+}) => (
+  <Alert variant="info" className="px-3 shadow-none mb-1 py-10px bg-light-200">
+    <div className="d-flex align-items-center flex-nowrap w-100">
+      <DeleteOutline className="mr-2 text-dark-500 flex-shrink-0 deleted-content-icon" />
+      <div className="d-flex align-items-center flex-nowrap text-gray-700 font-style min-w-0">
+        <span className="text-nowrap">{message}</span>
+        <div className="ml-1 d-flex align-items-center flex-nowrap">
+          <AuthorLabel
+            author={deletedBy}
+            authorLabel={deletedByLabel}
+            labelColor={AvatarOutlineAndLabelColors[deletedByLabel] && `text-${AvatarOutlineAndLabelColors[deletedByLabel]}`}
+            linkToProfile
+            postOrComment
+            singleLine
+            postData={postData}
+          />
+        </div>
+      </div>
+    </div>
+  </Alert>
+);
+
+DeletedByBanner.propTypes = {
+  deletedBy: PropTypes.string.isRequired,
+  deletedByLabel: PropTypes.string,
+  message: PropTypes.string,
+  postData: PropTypes.shape({}),
+};
+
+DeletedByBanner.defaultProps = {
+  deletedByLabel: null,
+  message: '',
+  postData: null,
+};
+
+export default React.memo(DeletedByBanner);

--- a/src/discussions/common/DeletedByBanner.test.jsx
+++ b/src/discussions/common/DeletedByBanner.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { AvatarOutlineAndLabelColors } from '../../data/constants';
+import DeletedByBanner from './DeletedByBanner';
+
+const mockAuthorLabel = jest.fn(() => <div data-testid="author-label" />);
+
+jest.mock('./AuthorLabel', () => props => mockAuthorLabel(props));
+
+describe('DeletedByBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders delete icon, message, and author label', () => {
+    render(
+      <DeletedByBanner
+        deletedBy="moderator-user"
+        deletedByLabel="staff"
+        message="Deleted by"
+      />,
+    );
+
+    expect(document.querySelector('.deleted-content-icon')).toBeInTheDocument();
+    expect(screen.getByText('Deleted by')).toBeInTheDocument();
+    expect(screen.getByTestId('author-label')).toBeInTheDocument();
+  });
+
+  it('passes contract props to AuthorLabel including optional postData', () => {
+    const postData = { learner_status: 'new' };
+
+    render(
+      <DeletedByBanner
+        deletedBy="moderator-user"
+        deletedByLabel="staff"
+        message="Deleted by"
+        postData={postData}
+      />,
+    );
+
+    expect(mockAuthorLabel).toHaveBeenCalledWith(expect.objectContaining({
+      author: 'moderator-user',
+      authorLabel: 'staff',
+      labelColor: AvatarOutlineAndLabelColors.staff && `text-${AvatarOutlineAndLabelColors.staff}`,
+      linkToProfile: true,
+      postOrComment: true,
+      singleLine: true,
+      postData,
+    }));
+  });
+});

--- a/src/discussions/common/EndorsedAlertBanner.jsx
+++ b/src/discussions/common/EndorsedAlertBanner.jsx
@@ -47,7 +47,7 @@ const EndorsedAlertBanner = ({
               {intl.formatMessage(isQuestion ? messages.answer : messages.endorsed)}
             </strong>
           </div>
-          <span className="d-flex align-items-center align-items-center flex-wrap" style={{ marginRight: '-1px' }}>
+          <span className="d-flex align-items-center flex-nowrap" style={{ marginRight: '-1px' }}>
             <AuthorLabel
               author={endorsedBy}
               authorLabel={endorsedByLabel}
@@ -56,6 +56,8 @@ const EndorsedAlertBanner = ({
               postCreatedAt={endorsedAt}
               authorToolTip
               postOrComment
+              singleLine
+              roleBeforeTimestamp
             />
           </span>
         </div>

--- a/src/discussions/common/index.js
+++ b/src/discussions/common/index.js
@@ -4,4 +4,5 @@ export { default as AuthorLabel } from './AuthorLabel';
 export { default as AutoSpamAlertBanner } from './AutoSpamAlertBanner';
 export { default as BanModerationModals } from './BanModerationModals';
 export { default as Confirmation } from './Confirmation';
+export { default as DeletedByBanner } from './DeletedByBanner';
 export { default as EndorsedAlertBanner } from './EndorsedAlertBanner';

--- a/src/discussions/learners/LearnerActionsDropdown.jsx
+++ b/src/discussions/learners/LearnerActionsDropdown.jsx
@@ -17,6 +17,7 @@ const LearnerActionsDropdown = ({
   dropDownIconSize,
   userHasBulkDeletePrivileges,
   learnerBanInfo,
+  contentStatus,
 }) => {
   const buttonRef = useRef();
   const intl = useIntl();
@@ -25,7 +26,7 @@ const LearnerActionsDropdown = ({
   const [submenuOpen, setSubmenuOpen] = useState(null);
   const [submenuTarget, setSubmenuTarget] = useState(null);
   const submenuRef = useRef({});
-  const actions = useLearnerActions(userHasBulkDeletePrivileges, learnerBanInfo);
+  const actions = useLearnerActions(userHasBulkDeletePrivileges, learnerBanInfo, contentStatus);
 
   // Cleanup refs when actions change to prevent memory leaks
   useEffect(() => {
@@ -201,12 +202,14 @@ LearnerActionsDropdown.propTypes = {
     isAuthorBanned: PropTypes.bool,
     authorBanScope: PropTypes.string,
   }),
+  contentStatus: PropTypes.string,
 };
 
 LearnerActionsDropdown.defaultProps = {
   dropDownIconSize: false,
   userHasBulkDeletePrivileges: false,
   learnerBanInfo: {},
+  contentStatus: undefined,
 };
 
 export default LearnerActionsDropdown;

--- a/src/discussions/learners/LearnerActionsDropdown.test.jsx
+++ b/src/discussions/learners/LearnerActionsDropdown.test.jsx
@@ -10,7 +10,7 @@ import { initializeMockApp } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { AppProvider } from '@edx/frontend-platform/react';
 
-import { ContentActions } from '../../data/constants';
+import { ContentActions, PostsStatusFilter } from '../../data/constants';
 import { initializeStore } from '../../store';
 import executeThunk from '../../test-utils';
 import { getCourseConfigApiUrl } from '../data/api';
@@ -26,6 +26,7 @@ const renderComponent = ({
   contentType = 'LEARNER',
   userHasBulkDeletePrivileges = false,
   actionHandlers = {},
+  contentStatus,
 } = {}) => {
   render(
     <IntlProvider locale="en">
@@ -34,6 +35,7 @@ const renderComponent = ({
           contentType={contentType}
           userHasBulkDeletePrivileges={userHasBulkDeletePrivileges}
           actionHandlers={actionHandlers}
+          contentStatus={contentStatus}
         />
       </AppProvider>
     </IntlProvider>,
@@ -170,5 +172,22 @@ describe('LearnerActionsDropdown', () => {
     await waitFor(() => expect(screen.queryByTestId('learner-actions-dropdown-modal-popup')).not.toBeInTheDocument());
     expect(mockDeleteOrgHandler).toHaveBeenCalled();
     expect(mockDeleteCourseHandler).not.toHaveBeenCalled();
+  });
+
+  it('shows restore-only learner actions in deleted filter', async () => {
+    renderComponent({
+      userHasBulkDeletePrivileges: true,
+      contentStatus: PostsStatusFilter.DELETED,
+    });
+
+    const openButton = await findOpenActionsDropdownButton();
+    await act(async () => {
+      fireEvent.click(openButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('delete-activity')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('restore-activity')).toBeInTheDocument();
+    });
   });
 });

--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -323,6 +323,7 @@ const LearnerPostsView = () => {
               actionHandlers={actionHandlers}
               userHasBulkDeletePrivileges={userHasBulkDeletePrivileges}
               learnerBanInfo={learnerBanInfo}
+              contentStatus={postFilter?.contentStatus}
               dropDownIconSize
             />
           </div>

--- a/src/discussions/learners/utils.js
+++ b/src/discussions/learners/utils.js
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { ContentActions } from '../../data/constants';
+import { ContentActions, PostsStatusFilter } from '../../data/constants';
 import { selectEnableDiscussionBan } from '../data/selectors';
 import { checkBanActionDisabled } from '../utils/banUtils';
 import { BAN_SCOPES } from './data/constants';
@@ -104,7 +104,11 @@ const checkDisabled = (learnerBanInfo, disabledConditions) => {
   return false;
 };
 
-export function useLearnerActions(userHasBulkDeletePrivileges = false, learnerBanInfo = {}) {
+export function useLearnerActions(
+  userHasBulkDeletePrivileges = false,
+  learnerBanInfo = {},
+  contentStatus = PostsStatusFilter.ACTIVE,
+) {
   const intl = useIntl();
   const enableDiscussionBan = useSelector(selectEnableDiscussionBan);
 
@@ -118,6 +122,15 @@ export function useLearnerActions(userHasBulkDeletePrivileges = false, learnerBa
       if (action.id === 'ban' && !enableDiscussionBan) {
         return false;
       }
+
+      if (contentStatus === PostsStatusFilter.DELETED && action.id === 'delete-activity') {
+        return false;
+      }
+
+      if (contentStatus !== PostsStatusFilter.DELETED && action.id === 'restore-activity') {
+        return false;
+      }
+
       return true;
     }).map(action => {
       // For actions with submenus, check disabled conditions
@@ -170,7 +183,7 @@ export function useLearnerActions(userHasBulkDeletePrivileges = false, learnerBa
         },
       };
     }).filter(Boolean); // Remove null entries (actions with empty submenus)
-  }, [userHasBulkDeletePrivileges, learnerBanInfo, enableDiscussionBan, intl]);
+  }, [userHasBulkDeletePrivileges, learnerBanInfo, contentStatus, enableDiscussionBan, intl]);
 
   return actions;
 }

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -18,12 +18,15 @@ import HTMLLoader from '../../../../components/HTMLLoader';
 import {
   banUser, bulkDeleteUserPosts, unbanUser,
 } from '../../../../data/api/moderation';
-import { ContentActions, EndorsementStatus } from '../../../../data/constants';
+import {
+  ContentActions, EndorsementStatus,
+} from '../../../../data/constants';
 import {
   AlertBanner,
   AutoSpamAlertBanner,
   BanModerationModals,
   Confirmation,
+  DeletedByBanner,
   EndorsedAlertBanner,
 } from '../../../common';
 import DiscussionContext from '../../../common/context';
@@ -40,6 +43,7 @@ import {
 import { fetchThread } from '../../../posts/data/thunks';
 import LikeButton from '../../../posts/post/LikeButton';
 import { useActions } from '../../../utils';
+import { useShowDeletedContent } from '../../data/hooks';
 import {
   selectCommentCurrentPage,
   selectCommentHasMorePages,
@@ -70,7 +74,7 @@ const Comment = ({
   const {
     id, parentId, childCount, abuseFlagged, endorsed, threadId, endorsedAt, endorsedBy, endorsedByLabel, renderedBody,
     voted, following, voteCount, authorLabel, author, createdAt, lastEdit, rawBody, closed, closedBy, closeReason,
-    editByLabel, closedByLabel, users: postUsers, is_spam: isSpam,
+    editByLabel, closedByLabel, users: postUsers, isDeleted, deletedBy, deletedByLabel, is_spam: isSpam,
   } = comment;
   const intl = useIntl();
   const hasChildren = childCount > 0;
@@ -138,6 +142,7 @@ const Comment = ({
   const shouldShowEmailConfirmation = useSelector(selectShouldShowEmailConfirmation);
   const contentCreationRateLimited = useSelector(selectContentCreationRateLimited);
   const isUserBanned = useSelector(selectIsUserBanned);
+  const showDeleted = useShowDeletedContent();
   // If isSpam is not provided in the API response, default to false
   const isSpamFlagged = isSpam || false;
   useEffect(() => {
@@ -146,9 +151,10 @@ const Comment = ({
       dispatch(fetchCommentResponses(id, {
         page: 1,
         reverseOrder: sortedOrder,
+        showDeleted,
       }));
     }
-  }, [id, sortedOrder]);
+  }, [id, sortedOrder, showDeleted]);
 
   const endorseIcons = useMemo(() => (
     actions.find(({ action }) => action === EndorsementStatus.ENDORSED)
@@ -352,8 +358,9 @@ const Comment = ({
     dispatch(fetchCommentResponses(id, {
       page: currentPage + 1,
       reverseOrder: sortedOrder,
+      showDeleted,
     }))
-  ), [id, currentPage, sortedOrder]);
+  ), [id, currentPage, sortedOrder, showDeleted]);
 
   const handleAddCommentButton = useCallback(() => {
     if (isUserPrivilegedInPostingRestriction) {
@@ -444,8 +451,17 @@ const Comment = ({
             voted={voted}
             following={following}
             endorseIcons={endorseIcons}
+            isDeleted={isDeleted}
             isUserBanned={isUserBanned}
           />
+          {isDeleted && deletedBy && (
+            <DeletedByBanner
+              deletedBy={deletedBy}
+              deletedByLabel={deletedByLabel}
+              message={intl.formatMessage(messages.deletedBy)}
+              postData={comment}
+            />
+          )}
           <AlertBanner
             author={author}
             abuseFlagged={abuseFlagged}

--- a/src/discussions/post-comments/comments/comment/Comment.test.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.test.jsx
@@ -1,0 +1,187 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+
+import { PostsStatusFilter } from '../../../../data/constants';
+import DiscussionContext from '../../../common/context';
+import { fetchCommentResponses } from '../../data/thunks';
+import PostCommentsContext from '../../postCommentsContext';
+import Comment from './Comment';
+
+let mockCommentData;
+const mockHoverCard = jest.fn(() => <div data-testid="hover-card-mock" />);
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@openedx/paragon/icons', () => ({
+  DeleteOutline: 'DeleteOutline',
+}));
+
+jest.mock('../../../../components/HTMLLoader', () => 'HTMLLoader');
+jest.mock('./CommentEditor', () => 'CommentEditor');
+jest.mock('./CommentHeader', () => 'CommentHeader');
+jest.mock('./Reply', () => 'Reply');
+
+jest.mock('../../../common/HoverCard', () => (props) => mockHoverCard(props));
+jest.mock('../../../posts/post/LikeButton', () => 'LikeButton');
+
+jest.mock('../../../common', () => ({
+  AlertBanner: 'AlertBanner',
+  AuthorLabel: 'AuthorLabel',
+  AutoSpamAlertBanner: 'AutoSpamAlertBanner',
+  BanModerationModals: 'BanModerationModals',
+  Confirmation: 'Confirmation',
+  DeletedByBanner: () => <div className="deleted-content-icon" />,
+  EndorsedAlertBanner: 'EndorsedAlertBanner',
+}));
+
+jest.mock('../../../common/withPostingRestrictions', () => Component => Component);
+
+jest.mock('../../data/selectors', () => ({
+  selectCommentCurrentPage: jest.fn(() => () => 1),
+  selectCommentHasMorePages: jest.fn(() => () => false),
+  selectCommentOrResponseById: jest.fn(() => () => mockCommentData),
+  selectCommentResponses: jest.fn(() => () => []),
+  selectCommentResponsesIds: jest.fn(() => () => []),
+  selectCommentSortOrder: jest.fn(() => false),
+}));
+
+jest.mock('../../../data/selectors', () => ({
+  selectContentCreationRateLimited: jest.fn(() => false),
+  selectIsUserBanned: jest.fn(() => false),
+  selectShouldShowEmailConfirmation: jest.fn(() => false),
+  selectUserHasModerationPrivileges: jest.fn(() => true),
+}));
+
+jest.mock('../../../data/hooks', () => ({
+  useUserPostingEnabled: jest.fn(() => true),
+}));
+
+jest.mock('../../../utils', () => ({
+  useActions: jest.fn(() => []),
+}));
+
+jest.mock('../../data/thunks', () => ({
+  editComment: jest.fn(),
+  fetchCommentResponses: jest.fn(() => ({ type: 'FETCH_COMMENT_RESPONSES' })),
+  performRestoreComment: jest.fn(),
+  removeComment: jest.fn(),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const baseComment = {
+  id: 'comment-1',
+  parentId: null,
+  childCount: 0,
+  abuseFlagged: false,
+  endorsed: false,
+  threadId: 'post-1',
+  endorsedAt: null,
+  endorsedBy: null,
+  endorsedByLabel: null,
+  renderedBody: '<p>Comment body</p>',
+  voted: false,
+  following: false,
+  voteCount: 0,
+  authorLabel: 'staff',
+  author: 'comment-author',
+  createdAt: '2025-01-01T00:00:00Z',
+  lastEdit: null,
+  rawBody: 'Comment body',
+  closed: false,
+  closedBy: null,
+  closeReason: null,
+  editByLabel: null,
+  closedByLabel: null,
+  users: {},
+  isDeleted: false,
+  deletedBy: null,
+  deletedByLabel: null,
+  is_spam: false,
+};
+
+const renderComment = (commentOverrides = {}, { showFullThread = false } = {}) => {
+  mockCommentData = { ...baseComment, ...commentOverrides };
+
+  return render(
+    <IntlProvider locale="en">
+      <MemoryRouter>
+        <DiscussionContext.Provider
+          value={{
+            courseId: 'course-v1:edX+DemoX+Demo_Course',
+            enableDiscussionBan: true,
+            learnerUsername: 'learner-1',
+          }}
+        >
+          <PostCommentsContext.Provider value={{ isClosed: false }}>
+            <Comment
+              commentId="comment-1"
+              marginBottom={false}
+              showFullThread={showFullThread}
+              openRestrictionDialogue={jest.fn()}
+            />
+          </PostCommentsContext.Provider>
+        </DiscussionContext.Provider>
+      </MemoryRouter>
+    </IntlProvider>,
+  );
+};
+
+describe('Comment deleted-by banner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDispatch.mockReturnValue(jest.fn());
+    useSelector.mockImplementation(selector => (typeof selector === 'function' ? selector({}) : selector));
+  });
+
+  it('renders deleted-by banner when isDeleted=true and deletedBy is present', () => {
+    const { container } = renderComment({ isDeleted: true, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).toBeInTheDocument();
+  });
+
+  it('passes isDeleted to HoverCard for deleted comments', () => {
+    renderComment({ isDeleted: true, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(mockHoverCard).toHaveBeenCalled();
+    expect(mockHoverCard.mock.calls[0][0]).toEqual(expect.objectContaining({ isDeleted: true }));
+  });
+
+  it('does not render deleted-by banner when deletedBy is not present', () => {
+    const { container } = renderComment({ isDeleted: true, deletedBy: null, deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).not.toBeInTheDocument();
+  });
+
+  it('requests deleted replies when learner deleted filter is active', async () => {
+    useSelector.mockImplementation((selector) => {
+      const mockState = {
+        learners: {
+          postFilter: {
+            contentStatus: PostsStatusFilter.DELETED,
+          },
+        },
+      };
+      return typeof selector === 'function' ? selector(mockState) : selector;
+    });
+
+    renderComment({ childCount: 2 }, { showFullThread: true });
+
+    await waitFor(() => {
+      expect(fetchCommentResponses).toHaveBeenCalledWith('comment-1', {
+        page: 1,
+        reverseOrder: false,
+        showDeleted: true,
+      });
+    });
+  });
+});

--- a/src/discussions/post-comments/comments/comment/Reply.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.jsx
@@ -14,7 +14,7 @@ import {
 } from '../../../../data/api/moderation';
 import { AvatarOutlineAndLabelColors, ContentActions } from '../../../../data/constants';
 import {
-  ActionsDropdown, AlertBanner, AuthorLabel, AutoSpamAlertBanner, Confirmation,
+  ActionsDropdown, AlertBanner, AuthorLabel, AutoSpamAlertBanner, Confirmation, DeletedByBanner,
 } from '../../../common';
 import DiscussionContext from '../../../common/context';
 import timeLocale from '../../../common/time-locale';
@@ -35,7 +35,8 @@ const Reply = ({ responseId }) => {
   const commentData = useSelector(selectCommentOrResponseById(responseId));
   const {
     id, abuseFlagged, author, authorLabel, endorsed, lastEdit, closed, closedBy,
-    closeReason, createdAt, threadId, parentId, rawBody, renderedBody, editByLabel, closedByLabel, is_spam: isSpam,
+    closeReason, createdAt, threadId, parentId, rawBody, renderedBody, editByLabel,
+    closedByLabel, isDeleted, deletedBy, deletedByLabel, is_spam: isSpam,
   } = commentData;
   const intl = useIntl();
   const dispatch = useDispatch();
@@ -303,6 +304,21 @@ const Reply = ({ responseId }) => {
           </div>
           <div className="w-100">
             <AutoSpamAlertBanner autoSpamFlagged={isSpamFlagged} />
+          </div>
+        </div>
+      )}
+      {isDeleted && deletedBy && (
+        <div className="d-flex">
+          <div className="d-flex invisible">
+            <Avatar />
+          </div>
+          <div className="w-100">
+            <DeletedByBanner
+              deletedBy={deletedBy}
+              deletedByLabel={deletedByLabel}
+              message={intl.formatMessage(messages.deletedBy)}
+              postData={commentData}
+            />
           </div>
         </div>
       )}

--- a/src/discussions/post-comments/comments/comment/Reply.test.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.test.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+
+import DiscussionContext from '../../../common/context';
+import Reply from './Reply';
+
+let mockReplyData;
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('@openedx/paragon', () => ({
+  Avatar: 'Avatar',
+  useToggle: jest.fn(() => [false, jest.fn(), jest.fn()]),
+}));
+
+jest.mock('@openedx/paragon/icons', () => ({
+  DeleteOutline: 'DeleteOutline',
+}));
+
+jest.mock('../../../../components/HTMLLoader', () => 'HTMLLoader');
+jest.mock('./CommentEditor', () => 'CommentEditor');
+
+jest.mock('../../../common', () => ({
+  ActionsDropdown: 'ActionsDropdown',
+  AlertBanner: 'AlertBanner',
+  AuthorLabel: 'AuthorLabel',
+  AutoSpamAlertBanner: 'AutoSpamAlertBanner',
+  Confirmation: 'Confirmation',
+  DeletedByBanner: () => <div className="deleted-content-icon" />,
+}));
+
+jest.mock('../../../posts/post/DeleteWithBanConfirmation', () => 'DeleteWithBanConfirmation');
+
+jest.mock('../../data/selectors', () => ({
+  selectCommentOrResponseById: jest.fn(() => () => mockReplyData),
+}));
+
+jest.mock('../../../posts/data/selectors', () => ({
+  selectAuthorAvatar: jest.fn(() => () => ({ imageUrlSmall: '' })),
+}));
+
+jest.mock('../../../data/hooks', () => ({
+  useAlertBannerVisible: jest.fn(() => false),
+}));
+
+jest.mock('../../../data/selectors', () => ({
+  selectIsUserBanned: jest.fn(() => false),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const baseReply = {
+  id: 'reply-1',
+  abuseFlagged: false,
+  author: 'reply-author',
+  authorLabel: 'staff',
+  endorsed: false,
+  lastEdit: null,
+  closed: false,
+  closedBy: null,
+  closeReason: null,
+  createdAt: '2025-01-01T00:00:00Z',
+  threadId: 'post-1',
+  parentId: 'comment-1',
+  rawBody: 'Reply body',
+  renderedBody: '<p>Reply body</p>',
+  editByLabel: null,
+  closedByLabel: null,
+  isDeleted: false,
+  deletedBy: null,
+  deletedByLabel: null,
+  is_spam: false,
+};
+
+const renderReply = (replyOverrides = {}) => {
+  mockReplyData = { ...baseReply, ...replyOverrides };
+
+  return render(
+    <IntlProvider locale="en">
+      <DiscussionContext.Provider
+        value={{
+          courseId: 'course-v1:edX+DemoX+Demo_Course',
+          enableDiscussionBan: true,
+        }}
+      >
+        <Reply responseId="reply-1" />
+      </DiscussionContext.Provider>
+    </IntlProvider>,
+  );
+};
+
+describe('Reply deleted-by banner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDispatch.mockReturnValue(jest.fn());
+    useSelector.mockImplementation(selector => (typeof selector === 'function' ? selector({}) : selector));
+  });
+
+  it('renders deleted-by banner when isDeleted=true and deletedBy is present', () => {
+    const { container } = renderReply({ isDeleted: true, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).toBeInTheDocument();
+  });
+
+  it('does not render deleted-by banner when isDeleted=false', () => {
+    const { container } = renderReply({ isDeleted: false, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).not.toBeInTheDocument();
+  });
+});

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -42,9 +42,9 @@ export function usePost(postId) {
   return thread || {};
 }
 
-const useShowDeletedContent = () => {
+export const useShowDeletedContent = () => {
   const { learnerUsername } = useContext(DiscussionContext);
-  const postFilter = useSelector(state => state.learners.postFilter);
+  const postFilter = useSelector(state => state.learners?.postFilter);
 
   // Show deleted content if we're in learner view and the deleted filter is active (contentStatus)
   return learnerUsername && postFilter?.contentStatus === PostsStatusFilter.DELETED;

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -20,7 +20,7 @@ import {
 import { ContentActions, getFullUrl } from '../../../data/constants';
 import { selectorForUnitSubsection, selectTopicContext } from '../../../data/selectors';
 import {
-  AlertBanner, AutoSpamAlertBanner, BanModerationModals, Confirmation,
+  AlertBanner, AutoSpamAlertBanner, BanModerationModals, Confirmation, DeletedByBanner,
 } from '../../common';
 import DiscussionContext from '../../common/context';
 import HoverCard from '../../common/HoverCard';
@@ -90,6 +90,9 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
     editByLabel,
     closedByLabel,
     users: postUsers,
+    isDeleted,
+    deletedBy,
+    deletedByLabel,
     is_spam: isSpam,
   } = threadData;
   const intl = useIntl();
@@ -495,8 +498,17 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         onFollow={handlePostFollow}
         voted={voted}
         following={following}
+        isDeleted={isDeleted}
         isUserBanned={isUserBanned}
       />
+      {isDeleted && deletedBy && (
+        <DeletedByBanner
+          deletedBy={deletedBy}
+          deletedByLabel={deletedByLabel}
+          message={intl.formatMessage(messages.deletedBy)}
+          postData={threadData}
+        />
+      )}
       <AlertBanner
         author={author}
         abuseFlagged={abuseFlagged}

--- a/src/discussions/posts/post/Post.test.jsx
+++ b/src/discussions/posts/post/Post.test.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+import DiscussionContext from '../../common/context';
+import Post from './Post';
+
+let mockThreadData;
+const mockHoverCard = jest.fn(() => <div data-testid="hover-card-mock" />);
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('@openedx/paragon/icons', () => ({
+  DeleteOutline: 'DeleteOutline',
+}));
+
+jest.mock('../../../components/HTMLLoader', () => 'HTMLLoader');
+jest.mock('../../common/HoverCard', () => (props) => mockHoverCard(props));
+jest.mock('./ClosePostReasonModal', () => 'ClosePostReasonModal');
+jest.mock('./PostFooter', () => 'PostFooter');
+jest.mock('./PostHeader', () => 'PostHeader');
+
+jest.mock('../../common', () => ({
+  AlertBanner: 'AlertBanner',
+  AuthorLabel: 'AuthorLabel',
+  AutoSpamAlertBanner: 'AutoSpamAlertBanner',
+  BanModerationModals: 'BanModerationModals',
+  Confirmation: 'Confirmation',
+  DeletedByBanner: () => <div className="deleted-content-icon" />,
+}));
+
+jest.mock('../../common/withPostingRestrictions', () => Component => Component);
+
+jest.mock('../data/selectors', () => ({
+  selectThread: jest.fn(() => () => mockThreadData),
+}));
+
+jest.mock('../../topics/data/selectors', () => ({
+  selectTopic: jest.fn(() => () => null),
+}));
+
+jest.mock('../../../data/selectors', () => ({
+  selectorForUnitSubsection: jest.fn(() => null),
+  selectTopicContext: jest.fn(() => null),
+}));
+
+jest.mock('../../data/selectors', () => ({
+  selectContentCreationRateLimited: jest.fn(() => false),
+  selectIsUserBanned: jest.fn(() => false),
+  selectShouldShowEmailConfirmation: jest.fn(() => false),
+  selectUserHasModerationPrivileges: jest.fn(() => true),
+}));
+
+jest.mock('../../utils', () => ({
+  useActions: jest.fn(() => []),
+}));
+
+jest.mock('@edx/frontend-platform', () => ({
+  ensureConfig: jest.fn(),
+  getConfig: jest.fn(() => ({ BASE_URL: 'http://localhost:18000' })),
+}));
+
+jest.mock('@edx/frontend-platform/logging', () => ({
+  logError: jest.fn(),
+}));
+
+const baseThread = {
+  topicId: 'topic-1',
+  abuseFlagged: false,
+  closed: false,
+  pinned: false,
+  voted: false,
+  hasEndorsed: false,
+  following: false,
+  closedBy: null,
+  voteCount: 0,
+  groupId: null,
+  groupName: null,
+  closeReason: null,
+  authorLabel: 'staff',
+  type: 'discussion',
+  author: 'post-author',
+  title: 'Test Post',
+  createdAt: '2025-01-01T00:00:00Z',
+  renderedBody: '<p>Body</p>',
+  lastEdit: null,
+  editByLabel: null,
+  closedByLabel: null,
+  users: {},
+  isDeleted: false,
+  deletedBy: null,
+  deletedByLabel: null,
+  is_spam: false,
+};
+
+const renderPost = (threadOverrides = {}) => {
+  mockThreadData = { ...baseThread, ...threadOverrides };
+
+  return render(
+    <IntlProvider locale="en">
+      <MemoryRouter>
+        <DiscussionContext.Provider
+          value={{
+            enableInContextSidebar: false,
+            postId: 'post-1',
+            courseId: 'course-v1:edX+DemoX+Demo_Course',
+          }}
+        >
+          <Post
+            handleAddResponseButton={jest.fn()}
+            openRestrictionDialogue={jest.fn()}
+          />
+        </DiscussionContext.Provider>
+      </MemoryRouter>
+    </IntlProvider>,
+  );
+};
+
+describe('Post deleted-by banner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useDispatch.mockReturnValue(jest.fn());
+    useSelector.mockImplementation((selector) => {
+      const mockState = {
+        config: { enableDiscussionBan: true },
+      };
+      return typeof selector === 'function' ? selector(mockState) : selector;
+    });
+    useLocation.mockReturnValue({ pathname: '/course/post-1', search: '' });
+  });
+
+  it('renders deleted-by banner when isDeleted=true and deletedBy is present', () => {
+    const { container } = renderPost({ isDeleted: true, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).toBeInTheDocument();
+  });
+
+  it('passes isDeleted to HoverCard for deleted posts', () => {
+    renderPost({ isDeleted: true, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(mockHoverCard).toHaveBeenCalled();
+    expect(mockHoverCard.mock.calls[0][0]).toEqual(expect.objectContaining({ isDeleted: true }));
+  });
+
+  it('does not render deleted-by banner when isDeleted=false', () => {
+    const { container } = renderPost({ isDeleted: false, deletedBy: 'deleted-mod', deletedByLabel: 'staff' });
+
+    expect(container.querySelector('.deleted-content-icon')).not.toBeInTheDocument();
+  });
+});

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -78,6 +78,7 @@ const PostLink = ({
   const authorLabelColor = AvatarOutlineAndLabelColors[authorLabel];
   const canSeeReportedBadge = abuseFlagged || abuseFlaggedCount;
   const isPostRead = read || (!read && commentCount !== unreadCommentCount);
+  const shouldUseSingleLineAuthorRole = ['learners', 'posts', 'my-posts'].includes(page);
 
   const checkIsSelected = useMemo(
     () => (
@@ -190,6 +191,7 @@ const PostLink = ({
             author={author || intl.formatMessage(messages.anonymous)}
             authorLabel={authorLabel}
             labelColor={authorLabelColor && `text-${authorLabelColor}`}
+            singleLine={shouldUseSingleLineAuthorRole}
             postData={threadData}
           />
           <PostSummaryFooter

--- a/src/discussions/posts/post/PostLink.test.jsx
+++ b/src/discussions/posts/post/PostLink.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import MockAdapter from 'axios-mock-adapter';
 import { IntlProvider } from 'react-intl';
 import { Factory } from 'rosie';
@@ -44,11 +44,11 @@ const mockThread = async (id, abuseFlagged) => {
   await executeThunk(fetchThread(id), store.dispatch, store.getState);
 };
 
-function renderComponent(id) {
+function renderComponent(id, page = 'posts', contextOverrides = {}) {
   return render(
     <IntlProvider locale="en">
       <AppProvider store={store}>
-        <DiscussionContext.Provider value={{ courseId, page: 'posts' }}>
+        <DiscussionContext.Provider value={{ courseId, page, ...contextOverrides }}>
           <PostLink
             key={id}
             postId={id}
@@ -104,4 +104,61 @@ describe('Post username', () => {
 
     expect(screen.queryByTestId('learner-posts-link')).not.toBeInTheDocument();
   });
+
+  it('does not show deleted by attribution in post list cards', async () => {
+    store = initializeStore();
+    Factory.resetAll();
+
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    axiosMock.onGet(`${courseConfigApiUrl}${courseId}/settings`).reply(200, {});
+    axiosMock.onGet(`${courseConfigApiUrl}${courseId}/`).reply(200, {
+      has_moderation_privileges: true,
+    });
+    axiosMock.onGet(`${threadsApiUrl}${postId}/`).reply(200, Factory.build('thread', {
+      id: postId,
+      is_deleted: true,
+      deleted_by: 'staff-user',
+      deleted_by_label: 'Staff',
+    }));
+
+    await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
+    await executeThunk(fetchThread(postId), store.dispatch, store.getState);
+
+    const { container } = renderComponent(postId);
+
+    expect(container.querySelector('.deleted-content-icon')).not.toBeInTheDocument();
+  });
+
+  it.each(['learners', 'posts', 'my-posts'])(
+    'shows author name and role on a single line for %s listing',
+    async (page) => {
+      store = initializeStore();
+      Factory.resetAll();
+
+      axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+      axiosMock.onGet(`${courseConfigApiUrl}${courseId}/settings`).reply(200, {});
+      axiosMock.onGet(`${courseConfigApiUrl}${courseId}/`).reply(200, {
+        has_moderation_privileges: true,
+      });
+      axiosMock.onGet(`${threadsApiUrl}${postId}/`).reply(200, Factory.build('thread', {
+        id: postId,
+        author: 'staff-user',
+        author_label: 'Staff',
+      }));
+
+      await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
+      await executeThunk(fetchThread(postId), store.dispatch, store.getState);
+
+      renderComponent(
+        postId,
+        page,
+        page === 'learners' ? { learnerUsername: 'staff-user' } : {},
+      );
+
+      const authorName = screen.getByRole('heading', { name: 'staff-user' });
+      const singleLineRow = authorName.closest('div.d-flex.align-items-center.flex-nowrap');
+      expect(singleLineRow).toBeInTheDocument();
+      expect(within(singleLineRow).getByText('Staff')).toBeInTheDocument();
+    },
+  );
 });

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -342,7 +342,10 @@ export function useActions(contentType, id, hasModerationPrivileges) {
           })
           .map(subAction => ({
             ...subAction,
-            disabled: checkDisabled(content, subAction.disabledConditions),
+            disabled: (
+              checkDisabled(content, subAction.disabledConditions)
+              || isActionDisabled(subAction.id, content.isDeleted)
+            ),
           }));
 
         // If only one submenu item remains, convert to direct action (no submenu)
@@ -361,6 +364,7 @@ export function useActions(contentType, id, hasModerationPrivileges) {
           return {
             ...action,
             submenu: filteredSubmenu,
+            disabled: filteredSubmenu.every(subAction => subAction.disabled),
           };
         }
 


### PR DESCRIPTION
This pull request introduces improvements to the handling and display of deleted content in discussion forums, especially for comments and learner actions. It adds new UI indicators for deleted comments, refines which actions are available based on content status, and enhances test coverage for these scenarios.

**Deleted Content Handling and UI:**

* Added a "deleted by" info banner with icon to comments that are marked as deleted and include information about who deleted them, improving user clarity. (`src/discussions/post-comments/comments/comment/Comment.jsx`, `src/discussions/post-comments/comments/comment/Comment.test.jsx`, [[1]](diffhunk://#diff-53259e8110f1344568f1c39937710d7fb0ed90f9b2a5815ac22d6ad28513e128R459-R475) [[2]](diffhunk://#diff-38c93de45ffe85b8c1aa467ab81cbc936801d7eb213f52e402f1a5214fa0dcd3R1-R146)
* Updated the comment fetching logic to respect the deleted content filter when displaying comments for a learner, ensuring deleted comments are shown only when appropriate. (`src/discussions/post-comments/comments/comment/Comment.jsx`, F0a37e5cL138R154, [src/discussions/post-comments/comments/comment/Comment.jsxR364-R366](diffhunk://#diff-53259e8110f1344568f1c39937710d7fb0ed90f9b2a5815ac22d6ad28513e128R364-R366))

**Action Dropdown Logic and Filtering:**

* Refined action dropdowns so that only relevant actions are shown for deleted content (e.g., "restore" is shown, "delete" is hidden) for both general and learner-specific dropdowns. (`src/discussions/common/ActionsDropdown.jsx`, `src/discussions/learners/LearnerActionsDropdown.jsx`, `src/discussions/learners/utils.js`, [[1]](diffhunk://#diff-b30ec3b92fa01ea9fa926808d41b4bff015fd0edda695146f6bde706d171f3e4L164-R163) [[2]](diffhunk://#diff-24271b1b840b0f52bf4b9adbbf18a25431c4cc857736065c70020714015ba711L28-R29) [[3]](diffhunk://#diff-1203dfe71677b24e31ce376df529816b179ebf301a2ca0d9a4af71b9f9f8daaeR125-R133)
* Passed `contentStatus` through relevant components and hooks to enable context-aware filtering of actions based on whether content is deleted or active. (`src/discussions/learners/LearnerActionsDropdown.jsx`, `src/discussions/learners/LearnerPostsView.jsx`, [[1]](diffhunk://#diff-24271b1b840b0f52bf4b9adbbf18a25431c4cc857736065c70020714015ba711R20) [[2]](diffhunk://#diff-473e95592c727bcdd231f7fc646344107d8cbf8289334faa7a49ae3091c5aee7R326)

**Testing Improvements:**

* Added and updated tests to verify correct action visibility and UI for deleted discussions and comments, including new cases for restore-only scenarios. (`src/discussions/common/ActionsDropdown.test.jsx`, `src/discussions/learners/LearnerActionsDropdown.test.jsx`, [[1]](diffhunk://#diff-7b2b1d18c990d18662ef89cbf4de51864604bc908071bc2e73743394669603faR255-R302) [[2]](diffhunk://#diff-acf598bb9ad328d8620a4dd2fddc4ea5048ed761371c507920498be604fd2068R176-R192)

These changes collectively improve the moderation experience and ensure users see accurate options and indicators when interacting with deleted content.…ttribution

### Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or GitHub issues.

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/edx-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.