### PR TITLE
fix: Fix discussion list overwrite on direct post refresh

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -91,7 +91,7 @@ const threadsSlice = createSlice({
       }
 
       const updatedPages = newState.pages.slice();
-      if (!updatedPages[page - 1]) {
+      if (isFilterChanged || page === 1 || !updatedPages[page - 1]) {
         updatedPages[page - 1] = ids;
       } else {
         updatedPages[page - 1] = [...new Set([...updatedPages[page - 1], ...ids])];
@@ -137,20 +137,21 @@ const threadsSlice = createSlice({
         avatars: { ...state.avatars, ...payload.avatars },
       }
     ),
-    fetchThreadByDirectLinkSuccess: (state, { payload }) => (
-      {
+    fetchThreadByDirectLinkSuccess: (state, { payload }) => {
+      const updatedPages = state.pages.slice();
+      if (!updatedPages[payload.page - 1]?.length) {
+        updatedPages[payload.page - 1] = payload.ids;
+      }
+
+      return {
         ...state,
         status: RequestStatus.SUCCESSFUL,
-        pages: [
-          ...state.pages.slice(0, payload.page - 1),
-          payload.ids,
-          ...state.pages.slice(payload.page),
-        ],
+        pages: updatedPages,
         threadsInTopic: { ...payload.threadsInTopic, ...state.threadsInTopic },
-        threadsById: { ...payload.threadsById, ...state.threadsById },
+        threadsById: { ...state.threadsById, ...payload.threadsById },
         avatars: { ...state.avatars, ...payload.avatars },
-      }
-    ),
+      };
+    },
     fetchThreadFailed: (state) => (
       {
         ...state,


### PR DESCRIPTION
## Description

Fixes COSMO2-786, where refreshing a discussion post detail page could cause the posts sidebar to show only the selected post instead of the full posts list.

The issue occurred because the direct-link single-thread fetch and the thread list fetch could both update `state.threads.pages`. If the single-thread response completed after the list response, it replaced `pages[0]` with only the selected post ID.

## Changes

- Ensure page 1 responses from the thread list API replace `pages[0]` with the authoritative list result.
- Prevent direct-link single-thread responses from overwriting an already-populated `pages[0]`.
- Allow single-thread responses to refresh `threadsById` data for the selected post.

## Testing

Not run. Change is limited to Redux state update logic.

## Ticket

[COSMO2-786](https://2u-internal.atlassian.net/browse/COSMO2-786)