### PR TITLE
fix: Prevent direct post fetch from overwriting discussions list

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -137,21 +137,15 @@ const threadsSlice = createSlice({
         avatars: { ...state.avatars, ...payload.avatars },
       }
     ),
-    fetchThreadByDirectLinkSuccess: (state, { payload }) => {
-      const updatedPages = state.pages.slice();
-      if (!updatedPages[payload.page - 1]?.length) {
-        updatedPages[payload.page - 1] = payload.ids;
-      }
-
-      return {
+    fetchThreadByDirectLinkSuccess: (state, { payload }) => (
+      {
         ...state,
         status: RequestStatus.SUCCESSFUL,
-        pages: updatedPages,
         threadsInTopic: { ...payload.threadsInTopic, ...state.threadsInTopic },
         threadsById: { ...state.threadsById, ...payload.threadsById },
         avatars: { ...state.avatars, ...payload.avatars },
-      };
-    },
+      }
+    ),
     fetchThreadFailed: (state) => (
       {
         ...state,


### PR DESCRIPTION
Fixes [COSMO2-786](https://2u-internal.atlassian.net/browse/COSMO2-786).

After creating a new discussion post and refreshing the post detail page, the posts sidebar could inconsistently show only the selected/latest post instead of the full posts list. In some cases, the sidebar could also briefly show only the selected post while the full list request was still loading.

The issue occurred because the direct-link single-thread fetch and the thread list fetch could both update `state.threads.pages`, which is used to render the posts sidebar.

## Changes

- Ensure page 1 responses from the thread list API replace `pages[0]` with the authoritative list result.
- Stop direct-link single-thread responses from updating `state.threads.pages`.
- Keep direct-link single-thread responses scoped to refreshing normalized post data in `threadsById`.

