### PR TITLE
fix: ensure anonymous post authors can delete their own content

### DIFF
--- a/src/discussions/post-comments/data/__factories__/comments.factory.js
+++ b/src/discussions/post-comments/data/__factories__/comments.factory.js
@@ -14,6 +14,7 @@ Factory.define('comment')
   .attr('child_count', ['childCount'], (childCount) => childCount)
   .attrs({
     author: 'edx',
+    author_id: '1',
     author_label: 'Staff',
     can_delete: true,
     created_at: () => (new Date()).toISOString(),

--- a/src/discussions/posts/data/__factories__/threads.factory.js
+++ b/src/discussions/posts/data/__factories__/threads.factory.js
@@ -29,6 +29,7 @@ Factory.define('thread')
       'copy_link',
     ],
     author: 'test_user',
+    author_id: '1',
     author_label: null,
     abuse_flagged: false,
     can_delete: true,

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -88,6 +88,12 @@ export function checkPermissions(
     if (hasModerationPrivileges) {
       return canDelete;
     }
+    // For anonymous posts (author and authorId are null), trust backend's canDelete
+    // since backend already verifies authorship without exposing identity
+    const isAnonymousPost = !author && !content.authorId;
+    if (isAnonymousPost) {
+      return canDelete;
+    }
     // Non-moderators (including Course Staff/Admin) can only delete/restore their own content
     return canDelete && isOwnContent;
   }
@@ -95,6 +101,11 @@ export function checkPermissions(
   if (action === ContentActions.DELETE_POST) {
     if (hasModerationPrivileges) {
       return true;
+    }
+    // For anonymous posts (author and authorId are null), trust backend's canDelete
+    const isAnonymousPost = !author && !content.authorId;
+    if (isAnonymousPost) {
+      return canDelete;
     }
     // Non-moderators (including Course Staff/Admin) can only delete their own posts
     return canDelete && isOwnContent;
@@ -469,7 +480,10 @@ export function useActions(contentType, id, hasModerationPrivileges) {
 
   const actions = useMemo(() => {
     // Check if current user is the content author
-    const isOwnContent = currentUser && baseContent?.author && currentUser === baseContent.author;
+    // For anonymous posts, author is "anonymous" but authorId contains the real user ID
+    const currentUserId = getAuthenticatedUser()?.userId;
+    const isOwnContent = (currentUser && baseContent?.author && currentUser === baseContent.author)
+      || (currentUserId && baseContent?.authorId && String(currentUserId) === String(baseContent.authorId));
 
     const filteredActions = ACTIONS_LIST.filter(
       ({


### PR DESCRIPTION
### Description
Fixes an issue where users cannot delete their own posts created using the “Post anonymously” option in Discussions.

### Root Cause
The backend does not return author_id for anonymous posts. As a result, the frontend cannot identify the post owner, causing the ownership check to fail and hiding the Delete option.

### Fix
Updated logic to correctly identify the post owner for anonymous posts, allowing them to see and use the Delete option without exposing their identity.

### After fix (Screenshot)
<img width="1267" height="890" alt="image" src="https://github.com/user-attachments/assets/30d1209e-ab10-4d6a-805d-368b21dc3374" />


### Ticket
[Cosmo2-914](https://2u-internal.atlassian.net/browse/COSMO2-914)

### Linked PR
https://github.com/edx/edx-platform/pull/258