### PR TITLE
fix: ban/unban inconsistencies and org-level 403 error

### DIFF
--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -1,8 +1,10 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import selectCourseTabs from '../../components/NavigationBar/data/selectors';
+import { DENIED, LOADED } from '../../components/NavigationBar/data/slice';
 import { PostsStatusFilter, ThreadType } from '../../data/constants';
-import { isCourseStatusValid } from '../utils';
+
+export const isCourseStatusValid = (courseStatus) => [DENIED, LOADED].includes(courseStatus);
 
 export const selectAnonymousPostingConfig = state => ({
   allowAnonymous: state.config.allowAnonymous,
@@ -24,6 +26,31 @@ export const selectUserIsGroupTa = state => state.config.isGroupTa;
 export const selectConfigLoadingStatus = state => state.config.status;
 
 export const selectUserRoles = state => state.config.userRoles;
+
+// Course-level permissions: Global Staff, Discussion Admin, Discussion Moderator
+// EXCLUDES: Course Instructor, Course Staff, Group TA, Community TA, Learners
+export const selectUserCanBanAtCourseLevel = createSelector(
+  [
+    state => state.config.isUserAdmin,
+    state => state.config.hasModerationPrivileges,
+  ],
+  (isUserAdmin, hasModerationPrivileges) => (
+    isUserAdmin || hasModerationPrivileges
+  ),
+);
+
+// Org-level permissions: Global Staff, Discussion Admin
+// EXCLUDES: Discussion Moderator, Course Instructor, Course Staff, Group TA, Community TA, Learners
+export const selectUserCanBanAtOrgLevel = createSelector(
+  [
+    state => state.config.isUserAdmin,
+    selectUserRoles,
+  ],
+  (isUserAdmin, userRoles = []) => (
+    isUserAdmin
+      || userRoles.includes('Administrator')
+  ),
+);
 
 export const selectDivisionSettings = state => state.config.settings;
 

--- a/src/discussions/discussions-home/DiscussionsHome.jsx
+++ b/src/discussions/discussions-home/DiscussionsHome.jsx
@@ -19,6 +19,7 @@ import {
   useCourseBlockData, useCourseDiscussionData, useIsOnTablet, useRedirectToThread, useSidebarVisible,
 } from '../data/hooks';
 import {
+  isCourseStatusValid,
   selectDiscussionProvider,
   selectEnableDiscussionBan,
   selectEnableInContext,
@@ -30,7 +31,6 @@ import EmptyPosts from '../empty-posts/EmptyPosts';
 import { EmptyTopic as InContextEmptyTopics } from '../in-context-topics/components';
 import messages from '../messages';
 import { selectPostEditorVisible } from '../posts/data/selectors';
-import { isCourseStatusValid } from '../utils';
 import useFeedbackWrapper from './FeedbackWrapper';
 
 const FooterSlot = lazy(() => import('@edx/frontend-component-footer').then(module => ({ default: module.FooterSlot })));

--- a/src/discussions/learners/LearnerActionsDropdown.jsx
+++ b/src/discussions/learners/LearnerActionsDropdown.jsx
@@ -62,6 +62,7 @@ const LearnerActionsDropdown = ({
       }}
       className="d-flex justify-content-start actions-dropdown-item"
       data-testid={action.id}
+      disabled={action.disabled}
     >
       <div className="d-flex align-items-center">
         <Icon

--- a/src/discussions/learners/LearnerActionsDropdown.test.jsx
+++ b/src/discussions/learners/LearnerActionsDropdown.test.jsx
@@ -66,9 +66,10 @@ describe('LearnerActionsDropdown', () => {
 
     await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);
 
-    // Set moderation privileges so learner actions are available
+    // Set moderation privileges and org-level permissions so learner actions are available
     store.dispatch(fetchConfigSuccess({
       hasModerationPrivileges: true,
+      isUserAdmin: true, // Needed for org-level delete permissions
     }));
   });
 

--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -22,6 +22,8 @@ import useDispatchWithState from '../../data/hooks';
 import { Confirmation } from '../common';
 import DiscussionContext from '../common/context';
 import {
+  selectUserCanBanAtCourseLevel,
+  selectUserCanBanAtOrgLevel,
   selectUserHasBulkDeletePrivileges,
   selectUserHasModerationPrivileges,
   selectUserIsStaff,
@@ -88,8 +90,14 @@ const LearnerPostsView = () => {
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   const userIsStaff = useSelector(selectUserIsStaff);
   const userHasBulkDeletePrivileges = useSelector(selectUserHasBulkDeletePrivileges);
-  // Only show bulk actions to users with actual moderation privileges (not Course Staff/Admin)
-  const canAccessBulkActions = userHasModerationPrivileges && userHasBulkDeletePrivileges;
+  const userCanBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
+  const userCanBanAtOrgLevel = useSelector(selectUserCanBanAtOrgLevel);
+  // Show bulk actions to users with bulk delete privileges AND
+  // (moderation privileges OR ban permissions)
+  // This includes Course Instructors who have ban permissions but not moderation privileges
+  const canAccessBulkActions = userHasBulkDeletePrivileges && (
+    userHasModerationPrivileges || userCanBanAtCourseLevel || userCanBanAtOrgLevel
+  );
   const personalMutedUsers = useSelector(selectPersonalMutedUsers());
   const courseWideMutedUsers = useSelector(selectCourseWideMutedUsers());
   const bulkDeleteStats = useSelector(selectBulkDeleteStats());

--- a/src/discussions/learners/LearnerPostsView.test.jsx
+++ b/src/discussions/learners/LearnerPostsView.test.jsx
@@ -24,7 +24,7 @@ import { deletePostsApiUrl, learnerPostsApiUrl } from './data/api';
 import { BAN_SCOPES } from './data/constants';
 import { fetchUserPosts } from './data/thunks';
 import LearnerPostsView from './LearnerPostsView';
-import { setUpPrivilages } from './test-utils';
+import { setUpPrivileges } from './test-utils';
 
 import '../cohorts/data/__factories__/cohorts.factory';
 import './data/__factories__';
@@ -90,7 +90,7 @@ describe('Learner Posts View', () => {
   });
 
   test('Reported icon is visible to moderator for post with reported comment', async () => {
-    await setUpPrivilages(axiosMock, store, true);
+    await setUpPrivileges(axiosMock, store, true);
     await waitFor(() => { renderComponent(); });
 
     expect(container.querySelector('[data-testid="reported-post"]')).toBeInTheDocument();
@@ -157,7 +157,7 @@ describe('Learner Posts View', () => {
     { searchBy: 'sort-votes', result: 2 },
     { searchBy: 'sort-activity', result: 2 },
   ])('successfully display learners by %s.', async ({ searchBy, result }) => {
-    await setUpPrivilages(axiosMock, store, true);
+    await setUpPrivileges(axiosMock, store, true);
     await renderComponent();
 
     const filterBar = container.querySelector('.collapsible-trigger');
@@ -183,7 +183,7 @@ describe('Learner Posts View', () => {
     { searchBy: 'type-all', result: 2 },
     { searchBy: 'cohort-1', result: 2 },
   ])('successfully display learners by %s.', async ({ searchBy, result }) => {
-    await setUpPrivilages(axiosMock, store, true);
+    await setUpPrivileges(axiosMock, store, true);
     axiosMock.onGet(getCohortsApiUrl(courseId)).reply(200, Factory.buildList('cohort', 3));
 
     await executeThunk(fetchCourseCohorts(courseId), store.dispatch, store.getState);
@@ -223,19 +223,19 @@ describe('Learner Posts View', () => {
   });
 
   test('should display dropdown menu button for bulk delete user posts for privileged users', async () => {
-    await setUpPrivilages(axiosMock, store, true, true);
+    await setUpPrivileges(axiosMock, store, true, true);
     await renderComponent();
     expect(within(container).queryByRole('button', { name: /actions menu/i })).toBeInTheDocument();
   });
 
   test('should NOT display dropdown menu button for bulk delete user posts for other users', async () => {
-    await setUpPrivilages(axiosMock, store, true, false);
+    await setUpPrivileges(axiosMock, store, true, false);
     await renderComponent();
     expect(within(container).queryByRole('button', { name: /actions menu/i })).not.toBeInTheDocument();
   });
 
   test('should display confirmation dialog when delete course posts is clicked', async () => {
-    await setUpPrivilages(axiosMock, store, true, true);
+    await setUpPrivileges(axiosMock, store, true, true);
     axiosMock.onPost(deletePostsApiUrl(courseId, username, BAN_SCOPES.COURSE, false))
       .reply(202, { thread_count: 2, comment_count: 3 });
     await renderComponent();
@@ -266,7 +266,7 @@ describe('Learner Posts View', () => {
   });
 
   test('should complete delete course posts flow and redirect', async () => {
-    await setUpPrivilages(axiosMock, store, true, true);
+    await setUpPrivileges(axiosMock, store, true, true);
     axiosMock.onPost(deletePostsApiUrl(courseId, username, BAN_SCOPES.COURSE, false))
       .reply(202, { thread_count: 2, comment_count: 3 });
     axiosMock.onPost(deletePostsApiUrl(courseId, username, BAN_SCOPES.COURSE, true))
@@ -305,7 +305,7 @@ describe('Learner Posts View', () => {
   });
 
   test('should close confirmation dialog when cancel is clicked', async () => {
-    await setUpPrivilages(axiosMock, store, true, true);
+    await setUpPrivileges(axiosMock, store, true, true);
     axiosMock.onPost(deletePostsApiUrl(courseId, username, 'course', false))
       .reply(202, { thread_count: 2, comment_count: 3 });
     await renderComponent();
@@ -341,7 +341,7 @@ describe('Learner Posts View', () => {
   });
 
   test('should display confirmation dialog for org posts deletion', async () => {
-    await setUpPrivilages(axiosMock, store, true, true);
+    await setUpPrivileges(axiosMock, store, true, true, true); // Added isUserAdmin=true for org-level permissions
     axiosMock.onPost(deletePostsApiUrl(courseId, username, 'org', false))
       .reply(202, { thread_count: 5, comment_count: 10 });
     await renderComponent();

--- a/src/discussions/learners/messages.js
+++ b/src/discussions/learners/messages.js
@@ -171,6 +171,16 @@ const messages = defineMessages({
     defaultMessage: 'Unban',
     description: 'Action to unban a user',
   },
+  banUserSimple: {
+    id: 'discussions.learner.actions.banSimple',
+    defaultMessage: 'Ban',
+    description: 'Simple ban action for moderators (course-wide only)',
+  },
+  unbanUserSimple: {
+    id: 'discussions.learner.actions.unbanSimple',
+    defaultMessage: 'Unban',
+    description: 'Simple unban action for moderators (course-wide only)',
+  },
   undeleteActivity: {
     id: 'discussions.learner.actions.undeleteActivity',
     defaultMessage: 'Undelete activity',

--- a/src/discussions/learners/test-utils.js
+++ b/src/discussions/learners/test-utils.js
@@ -75,10 +75,17 @@ export async function setupDeleteUserPostsMockResponse({
   return store.getState().learners;
 }
 
-export async function setUpPrivilages(axiosMock, store, hasModerationPrivileges, hasBulkDeletePrivileges) {
+export async function setUpPrivileges(
+  axiosMock,
+  store,
+  hasModerationPrivileges,
+  hasBulkDeletePrivileges,
+  isUserAdmin = false,
+) {
   axiosMock.onGet(getDiscussionsConfigUrl(courseId)).reply(200, {
     hasModerationPrivileges,
     hasBulkDeletePrivileges,
+    isUserAdmin, // For org-level ban/delete permissions
   });
 
   await executeThunk(fetchCourseConfig(courseId), store.dispatch, store.getState);

--- a/src/discussions/learners/utils.js
+++ b/src/discussions/learners/utils.js
@@ -8,7 +8,12 @@ import { useSelector } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { ContentActions, PostsStatusFilter } from '../../data/constants';
-import { selectEnableDiscussionBan, selectUserHasModerationPrivileges } from '../data/selectors';
+import {
+  selectEnableDiscussionBan,
+  selectUserCanBanAtCourseLevel,
+  selectUserCanBanAtOrgLevel,
+  selectUserHasModerationPrivileges,
+} from '../data/selectors';
 import { checkBanActionDisabled } from '../utils/banUtils';
 import { BAN_SCOPES } from './data/constants';
 import messages from './messages';
@@ -112,17 +117,17 @@ export function useLearnerActions(
   const intl = useIntl();
   const enableDiscussionBan = useSelector(selectEnableDiscussionBan);
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
+  const userCanBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
+  const userCanBanAtOrgLevel = useSelector(selectUserCanBanAtOrgLevel);
 
   const actions = useMemo(() => {
-    // Only allow bulk actions if user has both bulk delete privileges AND moderation privileges
-    // This excludes Course Staff/Admin who may have bulk delete but not moderation privileges
     if (!userHasBulkDeletePrivileges || !userHasModerationPrivileges) {
       return [];
     }
 
     return LEARNER_ACTIONS_LIST.filter(action => {
-      // Hide ban menu if feature flag is disabled
-      if (action.id === 'ban' && !enableDiscussionBan) {
+      // Hide ban menu if feature flag is disabled OR user lacks course-level ban permissions
+      if (action.id === 'ban' && (!enableDiscussionBan || !userCanBanAtCourseLevel)) {
         return false;
       }
 
@@ -136,7 +141,49 @@ export function useLearnerActions(
 
       return true;
     }).map(action => {
-      // For actions with submenus, check disabled conditions
+      // Special handling for ban action based on user permissions
+      if (action.id === 'ban') {
+        // Users without org-level permissions: show direct course-level action only
+        if (!userCanBanAtOrgLevel) {
+          const isBanned = learnerBanInfo.isAuthorBanned;
+          const banScope = learnerBanInfo.authorBanScope;
+
+          // Determine which action to show based on ban state
+          // Only show course-level ban/unban for users without org permissions
+          if (isBanned && banScope === BAN_SCOPES.COURSE) {
+            // User is banned at course level, show simple unban option
+            return {
+              id: 'unban-course',
+              icon: Block,
+              action: ContentActions.UNBAN_COURSE,
+              label: {
+                id: messages.unbanUserSimple.id,
+                defaultMessage: intl.formatMessage(messages.unbanUserSimple),
+              },
+              disabled: false,
+            };
+          } if (isBanned && banScope === BAN_SCOPES.ORGANIZATION) {
+            // User is banned at org level, users without org permissions can't unban
+            // Don't show any ban action
+            return null;
+          }
+          // User is not banned, show simple ban option
+          return {
+            id: 'ban-course',
+            icon: Block,
+            action: ContentActions.BAN_COURSE,
+            label: {
+              id: messages.banUserSimple.id,
+              defaultMessage: intl.formatMessage(messages.banUserSimple),
+            },
+            disabled: false,
+          };
+        }
+
+        // Users with org-level permissions: keep the existing submenu with both course and org options
+      }
+
+      // For actions with submenus (including ban action for users with org permissions)
       if (action.submenu) {
         const processedSubmenu = action.submenu
           .filter(subAction => {
@@ -149,6 +196,17 @@ export function useLearnerActions(
             )) {
               return false;
             }
+
+            // For users without org-level permissions, filter out org-level actions
+            if (!userCanBanAtOrgLevel && (
+              subAction.action === ContentActions.BAN_ORG
+              || subAction.action === ContentActions.UNBAN_ORG
+              || subAction.action === ContentActions.DELETE_ORG_POSTS
+              || subAction.action === ContentActions.RESTORE_ORG_POSTS
+            )) {
+              return false;
+            }
+
             return true;
           })
           .map(subAction => {
@@ -189,6 +247,8 @@ export function useLearnerActions(
   }, [
     userHasBulkDeletePrivileges,
     userHasModerationPrivileges,
+    userCanBanAtCourseLevel,
+    userCanBanAtOrgLevel,
     learnerBanInfo,
     contentStatus,
     enableDiscussionBan,

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -42,6 +42,11 @@ const messages = defineMessages({
     defaultMessage: 'Ban',
     description: 'Main ban menu item',
   },
+  unbanAction: {
+    id: 'discussions.actions.unban',
+    defaultMessage: 'Unban',
+    description: 'Main unban menu item',
+  },
   banUserCourse: {
     id: 'discussions.actions.ban.course',
     defaultMessage: 'Ban user in this course',

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -16,16 +16,14 @@ import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 
 import { ReactComponent as RestoreFromTrash } from '../assets/undelete.svg';
-import { DENIED, LOADED } from '../components/NavigationBar/data/slice';
 import {
   ContentActions, Routes, ThreadType,
 } from '../data/constants';
 import { ContentSelectors } from './data/constants';
+import { selectUserCanBanAtCourseLevel, selectUserCanBanAtOrgLevel } from './data/selectors';
 import PostCommentsContext from './post-comments/postCommentsContext';
 import { checkBanActionDisabled } from './utils/banUtils';
 import messages from './messages';
-
-export const isCourseStatusValid = (courseStatus) => [DENIED, LOADED].includes(courseStatus);
 
 /**
  * Get HTTP Error status from generic error.
@@ -99,14 +97,16 @@ export function checkPermissions(
     // Non-moderators (including Course Staff/Admin) can only delete their own posts
     return canDelete && isOwnContent;
   }
-  // Ban/unban actions: require moderation privileges AND prevent self-banning
+  // Ban/unban actions: prevent self-banning/unbanning.
+  // Specific course/org ban permissions are enforced when the action menu is built,
+  // so this check must not narrow that logic back down to `hasModerationPrivileges`.
   if (action === ContentActions.BAN_COURSE
     || action === ContentActions.BAN_ORG
     || action === ContentActions.UNBAN_COURSE
     || action === ContentActions.UNBAN_ORG) {
     const currentUser = getAuthenticatedUser()?.username;
     const isSelf = currentUser && author && currentUser === author;
-    return hasModerationPrivileges && !isSelf;
+    return !isSelf;
   }
   // Bulk delete actions ONLY for users with moderation privileges (NOT Course Staff/Admin)
   if (action === ContentActions.DELETE_USER_COURSE
@@ -360,6 +360,9 @@ export function useActions(contentType, id, hasModerationPrivileges) {
   const isGlobalStaff = useSelector(state => state.config.isUserAdmin);
   // Discussion Admin/Moderator - has all discussion permissions
   const hasDiscussionModeratorPrivileges = useSelector(state => state.config.hasModerationPrivileges);
+  // Check if user can perform course-level and org-level bans
+  const canBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
+  const canBanAtOrgLevel = useSelector(selectUserCanBanAtOrgLevel);
   // Group TA - has limited permissions within their group
   const isUserGroupTA = useSelector(state => state.config.isGroupTa);
   // Course Staff/Admin - NO discussion privileges (treated as learners)
@@ -478,8 +481,8 @@ export function useActions(contentType, id, hasModerationPrivileges) {
         hasSubmenu = false,
         id: actionId,
       }) => {
-        // Hide ban menu if feature flag is disabled
-        if (actionId === 'ban' && !enableDiscussionBan) {
+        // Hide ban menu if feature flag is disabled OR user lacks course-level ban permissions
+        if (actionId === 'ban' && (!enableDiscussionBan || !canBanAtCourseLevel)) {
           return false;
         }
         // For items with submenus, skip permission check on parent item
@@ -532,6 +535,42 @@ export function useActions(contentType, id, hasModerationPrivileges) {
         };
       }
 
+      // Special handling for ban action based on user permissions
+      if (action.id === 'ban') {
+        // Users without org-level permissions: show direct course-level action only
+        if (!canBanAtOrgLevel) {
+          const isBanned = content.isAuthorBanned;
+          const banScope = content.authorBanScope;
+
+          // Determine which action to show based on ban state
+          // Only show course-level ban/unban for users without org permissions
+          if (isBanned && banScope === 'course') {
+            // User is banned at course level, show simple unban option
+            return {
+              id: 'unban-course',
+              icon: Block,
+              action: ContentActions.UNBAN_COURSE,
+              label: messages.unbanAction,
+              disabled: isActionDisabled('unban-course', content.isDeleted),
+            };
+          } if (isBanned && banScope === 'organization') {
+            // User is banned at org level, users without org permissions can't unban
+            // Don't show any ban action
+            return null;
+          }
+          // User is not banned, show simple ban option
+          return {
+            id: 'ban-course',
+            icon: Block,
+            action: ContentActions.BAN_COURSE,
+            label: messages.banAction,
+            disabled: isActionDisabled('ban-course', content.isDeleted),
+          };
+        }
+
+        // Users with org-level permissions: fall through to normal submenu processing below
+      }
+
       // For actions with submenus, filter submenu items and check permissions
       if (action.submenu) {
         const filteredSubmenu = action.submenu
@@ -545,6 +584,16 @@ export function useActions(contentType, id, hasModerationPrivileges) {
             )) {
               return false;
             }
+
+            // For users without org-level permissions, filter out org-level actions
+            if (!canBanAtOrgLevel && (
+              subAction.action === ContentActions.BAN_ORG
+              || subAction.action === ContentActions.UNBAN_ORG
+              || subAction.action === ContentActions.DELETE_USER_ORG
+            )) {
+              return false;
+            }
+
             return checkPermissions(content, subAction.action, hasModerationPrivileges, contentType, isOwnContent);
           })
           .map(subAction => ({
@@ -590,6 +639,8 @@ export function useActions(contentType, id, hasModerationPrivileges) {
     content,
     hasModerationPrivileges,
     enableDiscussionBan,
+    canBanAtCourseLevel,
+    canBanAtOrgLevel,
     checkConditions,
     checkDisabled,
     isActionDisabled,


### PR DESCRIPTION
### Description
Ban/unban functionality is inconsistent across different contexts in Discussions.
- Org-level ban returns a 403 error
- Course-level ban works correctly
- Users banned from a comment/response cannot be unbanned from the same context
- Unban is only possible from the parent post
### Expected
Ban/unban should work consistently across org, course, posts, and comments.

### Ticket
[Cosmo2-893](https://2u-internal.atlassian.net/jira/software/c/projects/COSMO2/boards/6540?selectedIssue=COSMO2-893)
