### PR TITLE
fix: add validation for TA users in cohort visibility feature

### DIFF
--- a/src/discussions/data/selectors.js
+++ b/src/discussions/data/selectors.js
@@ -21,6 +21,8 @@ export const selectUserIsStaff = state => state.config.isUserAdmin;
 
 export const selectUserIsGroupTa = state => state.config.isGroupTa;
 
+export const selectUserIsCommunityTa = state => state.config.userRoles?.includes('Community TA');
+
 export const selectConfigLoadingStatus = state => state.config.status;
 
 export const selectUserRoles = state => state.config.userRoles;

--- a/src/discussions/data/thunks.js
+++ b/src/discussions/data/thunks.js
@@ -47,12 +47,12 @@ export default function fetchCourseConfig(courseId) {
       dispatch(fetchConfigRequest());
 
       const config = await getDiscussionsConfig(courseId);
-      if (config.has_moderation_privileges) {
+      if (config.has_moderation_privileges || config.is_user_admin) {
         const settings = await getDiscussionsSettings(courseId);
         Object.assign(config, { settings });
       }
 
-      if ((config.has_moderation_privileges || config.is_group_ta)) {
+      if ((config.has_moderation_privileges || config.is_group_ta || config.is_user_admin)) {
         learnerSort = LearnersOrdering.BY_FLAG;
       }
 

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -37,6 +37,7 @@ import {
   selectIsUserLearner,
   selectModerationSettings,
   selectUserHasModerationPrivileges,
+  selectUserIsCommunityTa,
   selectUserIsGroupTa,
   selectUserIsStaff,
 } from '../../data/selectors';
@@ -82,6 +83,7 @@ const PostEditor = ({
   const post = useSelector(editExisting ? selectThread(postId) : () => ({}));
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   const userIsGroupTa = useSelector(selectUserIsGroupTa);
+  const userIsCommunityTa = useSelector(selectUserIsCommunityTa);
   const settings = useSelector(selectDivisionSettings);
   const { allowAnonymous, allowAnonymousToPeers } = useSelector(selectAnonymousPostingConfig);
   const { editReasons } = useSelector(selectModerationSettings);
@@ -120,8 +122,8 @@ const PostEditor = ({
 
   const canSelectCohort = useCallback((tId) => {
     // If the user isn't privileged, they can't edit the cohort.
-    // If the topic is being edited the cohort can't be changed.
-    if (!userHasModerationPrivileges) {
+    // Community TAs are excluded from selecting cohort visibility.
+    if (!userHasModerationPrivileges || userIsCommunityTa) {
       return false;
     }
     if (nonCoursewareIds.includes(tId)) {
@@ -129,7 +131,7 @@ const PostEditor = ({
     }
     const isCohorting = settings.alwaysDivideInlineDiscussions || settings.dividedInlineDiscussions.includes(tId);
     return isCohorting;
-  }, [nonCoursewareIds, settings, userHasModerationPrivileges]);
+  }, [nonCoursewareIds, settings, userHasModerationPrivileges, userIsCommunityTa]);
 
   const initialValues = {
     postType: post?.type || 'discussion',


### PR DESCRIPTION
### Description
For Teaching Assistants (TAs) assigned to a cohort, the “Cohort Visibility” option should not be displayed when creating a post within their own cohort.
However, after the recent feature update, the “Cohort Visibility” dropdown is now visible to TA users during post creation, which contradicts the expected role-based UI behavior.

### Actual Result
“Cohort Visibility” dropdown is visible to the TA
### Expected Result
“Cohort Visibility” option should not be visible for TAs when posting in their own cohort

### Ticket
[Cosmo2-910](https://2u-internal.atlassian.net/browse/COSMO2-910)