### PR TITLE
fix: Removed duplicate spinner while posts loading

### DIFF
--- a/src/discussions/post-comments/PostCommentsView.jsx
+++ b/src/discussions/post-comments/PostCommentsView.jsx
@@ -100,15 +100,7 @@ const PostCommentsView = () => {
         <EmptyPage title={intl.formatMessage(messages.noThreadFound)} />
       );
     }
-    return (
-      <div style={{
-        position: 'absolute',
-        top: '50%',
-      }}
-      >
-        <Spinner animation="border" variant="primary" data-testid="loading-indicator" />
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
### Description
Duplicate spinner is showing when a post is selected and if the page is refreshed.

### Expected
While the posts are loading on the sidebar, The details view is checking if the threadId is set or not and showing a Spinner, But the threadId will be set only after the list on the sidebar is loaded. Causing the duplicate spinner on the UI.

### Ticket
https://2u-internal.atlassian.net/browse/COSMO2-905