### PR TITLE
fix: resolve read/unread state persistence issue

### DIFF
--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -38,7 +38,7 @@ export function usePost(postId) {
     if (thread && !thread.read) {
       dispatch(markThreadAsRead(postId));
     }
-  }, [postId]);
+  }, [postId, thread?.read, dispatch]);
 
   return thread || {};
 }

--- a/src/discussions/posts/data/redux.test.js
+++ b/src/discussions/posts/data/redux.test.js
@@ -207,4 +207,123 @@ describe('Threads/Posts data layer tests', () => {
       .not
       .toContain(threadId);
   });
+
+  describe('read state preservation', () => {
+    test('preserves read state when lastActivityAt unchanged', async () => {
+      const threadId = 'thread-1';
+      const lastActivityAt = '2023-01-01T00:00:00Z';
+
+      // Initial fetch with read=true
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: true, lastActivityAt }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+
+      // Refetch returns read=false but lastActivityAt unchanged (stale backend data)
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: false, lastActivityAt }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should preserve read=true since no new activity
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+      expect(store.getState().threads.threadsById[threadId].unreadCommentCount).toBe(0);
+    });
+
+    test('trusts backend when lastActivityAt changed', async () => {
+      const threadId = 'thread-1';
+
+      // Initial fetch with read=true
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: true, lastActivityAt: '2023-01-01T00:00:00Z' }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+
+      // Refetch returns read=false with new lastActivityAt (new activity)
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', {
+          id: threadId, read: false, lastActivityAt: '2023-01-02T00:00:00Z', unread_comment_count: 5,
+        }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should trust backend's unread state since activity changed
+      expect(store.getState().threads.threadsById[threadId].read).toBe(false);
+      expect(store.getState().threads.threadsById[threadId].unreadCommentCount).toBe(5);
+    });
+
+    test('falls back to commentCount when lastActivityAt undefined', async () => {
+      const threadId = 'thread-1';
+
+      // Initial fetch with read=true, no lastActivityAt
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: true, comment_count: 10 }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+
+      // Refetch returns read=false but commentCount unchanged
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: false, comment_count: 10 }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should preserve read=true since commentCount unchanged
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+    });
+
+    test('trusts backend when commentCount changed', async () => {
+      const threadId = 'thread-1';
+
+      // Initial fetch with read=true
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: true, comment_count: 10 }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+
+      // Refetch returns read=false with increased commentCount
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', {
+          id: threadId, read: false, comment_count: 12, unread_comment_count: 2,
+        }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should trust backend's unread state since commentCount changed
+      expect(store.getState().threads.threadsById[threadId].read).toBe(false);
+      expect(store.getState().threads.threadsById[threadId].unreadCommentCount).toBe(2);
+    });
+
+    test('trusts backend when no reliable activity markers', async () => {
+      const threadId = 'thread-1';
+
+      // Initial fetch with read=true, explicitly remove activity markers
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, { ...Factory.build('thread', { id: threadId, read: true }), lastActivityAt: null, comment_count: null });
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(true);
+
+      // Refetch returns read=false
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, { ...Factory.build('thread', { id: threadId, read: false, unread_comment_count: 3 }), lastActivityAt: null, comment_count: null });
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should trust backend since we can't verify no new activity
+      expect(store.getState().threads.threadsById[threadId].read).toBe(false);
+      expect(store.getState().threads.threadsById[threadId].unreadCommentCount).toBe(3);
+    });
+
+    test('does not preserve when thread was not previously read', async () => {
+      const threadId = 'thread-1';
+
+      // Initial fetch with read=false
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: false, lastActivityAt: '2023-01-01T00:00:00Z' }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+      expect(store.getState().threads.threadsById[threadId].read).toBe(false);
+
+      // Refetch still returns read=false
+      axiosMock.onGet(`${threadsApiUrl}${threadId}/`)
+        .replyOnce(200, Factory.build('thread', { id: threadId, read: false, lastActivityAt: '2023-01-01T00:00:00Z' }));
+      await executeThunk(fetchThread(threadId), store.dispatch, store.getState);
+
+      // Should remain false (no preservation logic applies)
+      expect(store.getState().threads.threadsById[threadId].read).toBe(false);
+    });
+  });
 });

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -24,6 +24,47 @@ const mergeThreadsInTopics = (dataFromState, dataFromPayload) => {
   }, {});
 };
 
+// Preserve read state during tab switches to prevent flickering.
+// Only preserve if user marked as read in current session and backend hasn't updated activity markers
+const mergeThreadsPreservingReadState = (existingThreadsById, newThreadsById) => {
+  const merged = { ...existingThreadsById };
+  Object.keys(newThreadsById).forEach(threadId => {
+    const existingThread = merged[threadId];
+    const newThread = newThreadsById[threadId];
+
+    // If thread exists, was marked as read, and backend says unread, check for new activity
+    if (existingThread?.read && !newThread.read) {
+      // Check multiple activity markers to detect new content
+      const hasLastActivityAt = existingThread.lastActivityAt != null && newThread.lastActivityAt != null;
+      const hasCommentCount = existingThread.commentCount != null && newThread.commentCount != null;
+
+      let hasNewActivity = false;
+
+      if (hasLastActivityAt) {
+        // Prefer lastActivityAt if available (most reliable)
+        hasNewActivity = existingThread.lastActivityAt !== newThread.lastActivityAt;
+      } else if (hasCommentCount) {
+        // Fallback to commentCount if lastActivityAt not available
+        hasNewActivity = existingThread.commentCount !== newThread.commentCount;
+      } else {
+        // If no reliable markers exist, trust backend's unread state to be safe
+        hasNewActivity = true;
+      }
+
+      if (!hasNewActivity) {
+        // No new activity detected, preserve client read state (handles stale backend data)
+        merged[threadId] = { ...newThread, read: true, unreadCommentCount: 0 };
+      } else {
+        // New activity detected, trust backend's unread state
+        merged[threadId] = newThread;
+      }
+    } else {
+      merged[threadId] = newThread;
+    }
+  });
+  return merged;
+};
+
 const threadsSlice = createSlice({
   name: 'thread',
   initialState: {
@@ -99,7 +140,7 @@ const threadsSlice = createSlice({
       newState.pages = updatedPages;
 
       newState.status = RequestStatus.SUCCESSFUL;
-      newState.threadsById = { ...newState.threadsById, ...threadsById };
+      newState.threadsById = mergeThreadsPreservingReadState(newState.threadsById, threadsById);
       newState.threadsInTopic = (isFilterChanged || page === 1)
         ? { ...threadsInTopic }
         : mergeThreadsInTopics(newState.threadsInTopic, threadsInTopic);
@@ -133,7 +174,7 @@ const threadsSlice = createSlice({
       {
         ...state,
         status: RequestStatus.SUCCESSFUL,
-        threadsById: { ...state.threadsById, ...payload.threadsById },
+        threadsById: mergeThreadsPreservingReadState(state.threadsById, payload.threadsById),
         avatars: { ...state.avatars, ...payload.avatars },
       }
     ),
@@ -142,7 +183,7 @@ const threadsSlice = createSlice({
         ...state,
         status: RequestStatus.SUCCESSFUL,
         threadsInTopic: { ...payload.threadsInTopic, ...state.threadsInTopic },
-        threadsById: { ...state.threadsById, ...payload.threadsById },
+        threadsById: mergeThreadsPreservingReadState(state.threadsById, payload.threadsById),
         avatars: { ...state.avatars, ...payload.avatars },
       }
     ),


### PR DESCRIPTION
## Description

This PR fixes an issue where discussion forum threads marked as read were incorrectly showing as unread after a page reload or tab switch.

### Cause

Thread read state was being overwritten by requests that did not contain valid user context, causing already-read threads to appear unread.

### Fix

Updated the discussion thread read-state handling to ignore requests without valid user context and preserve the correct read/unread status.

### Ticket

[COSMO2-904](https://2u-internal.atlassian.net/browse/COSMO2-904)

### Related PR

https://github.com/edx/forum/pull/48
