### PR TITLE
fix: resolve reported tag issue in sidebar

### DIFF
--- a/src/discussions/post-comments/data/thunks.js
+++ b/src/discussions/post-comments/data/thunks.js
@@ -3,6 +3,7 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import { selectEnableDiscussionBan } from '../../data/selectors';
 import { setContentCreationRateLimited } from '../../data/slices';
+import { updateThreadAbuseFlaggedCount } from '../../posts/data/slices';
 import { getHttpErrorStatus } from '../../utils';
 import {
   deleteComment, getCommentResponses, getThreadComments, postComment, updateComment,
@@ -143,7 +144,16 @@ export function editComment(commentId, comment) {
     try {
       dispatch(updateCommentRequest({ commentId }));
       const data = await updateComment(commentId, comment);
-      dispatch(updateCommentSuccess(camelCaseObject(data)));
+      const updatedComment = camelCaseObject(data);
+      dispatch(updateCommentSuccess(updatedComment));
+      // If the flagged state changed, update the parent thread's abuseFlaggedCount
+      if (comment.flagged !== undefined) {
+        const { threadId } = updatedComment;
+        if (threadId) {
+          const delta = comment.flagged ? 1 : -1;
+          dispatch(updateThreadAbuseFlaggedCount({ threadId, delta }));
+        }
+      }
     } catch (error) {
       if (getHttpErrorStatus(error) === 403) {
         dispatch(updateCommentDenied());

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -99,7 +99,18 @@ const threadsSlice = createSlice({
       newState.pages = updatedPages;
 
       newState.status = RequestStatus.SUCCESSFUL;
-      newState.threadsById = { ...newState.threadsById, ...threadsById };
+      // Merge threads while preserving abuseFlaggedCount when the new data doesn't include it
+      // (abuseFlaggedCount is only returned when count_flagged=true is requested)
+      const mergedThreadsById = { ...newState.threadsById };
+      Object.entries(threadsById).forEach(([id, thread]) => {
+        mergedThreadsById[id] = {
+          ...thread,
+          abuseFlaggedCount: thread.abuseFlaggedCount != null
+            ? thread.abuseFlaggedCount
+            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+        };
+      });
+      newState.threadsById = mergedThreadsById;
       newState.threadsInTopic = (isFilterChanged || page === 1)
         ? { ...threadsInTopic }
         : mergeThreadsInTopics(newState.threadsInTopic, threadsInTopic);
@@ -129,23 +140,43 @@ const threadsSlice = createSlice({
         status: RequestStatus.IN_PROGRESS,
       }
     ),
-    fetchThreadSuccess: (state, { payload }) => (
-      {
+    fetchThreadSuccess: (state, { payload }) => {
+      // Preserve abuseFlaggedCount from existing state if not present in the new data
+      const mergedThreadsById = { ...state.threadsById };
+      Object.entries(payload.threadsById).forEach(([id, thread]) => {
+        mergedThreadsById[id] = {
+          ...thread,
+          abuseFlaggedCount: thread.abuseFlaggedCount != null
+            ? thread.abuseFlaggedCount
+            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+        };
+      });
+      return {
         ...state,
         status: RequestStatus.SUCCESSFUL,
-        threadsById: { ...state.threadsById, ...payload.threadsById },
+        threadsById: mergedThreadsById,
         avatars: { ...state.avatars, ...payload.avatars },
-      }
-    ),
-    fetchThreadByDirectLinkSuccess: (state, { payload }) => (
-      {
+      };
+    },
+    fetchThreadByDirectLinkSuccess: (state, { payload }) => {
+      // Preserve abuseFlaggedCount from existing state if not present in the new data
+      const mergedThreadsById = { ...state.threadsById };
+      Object.entries(payload.threadsById).forEach(([id, thread]) => {
+        mergedThreadsById[id] = {
+          ...thread,
+          abuseFlaggedCount: thread.abuseFlaggedCount != null
+            ? thread.abuseFlaggedCount
+            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+        };
+      });
+      return {
         ...state,
         status: RequestStatus.SUCCESSFUL,
         threadsInTopic: { ...payload.threadsInTopic, ...state.threadsInTopic },
-        threadsById: { ...state.threadsById, ...payload.threadsById },
+        threadsById: mergedThreadsById,
         avatars: { ...state.avatars, ...payload.avatars },
-      }
-    ),
+      };
+    },
     fetchThreadFailed: (state) => (
       {
         ...state,
@@ -409,6 +440,22 @@ const threadsSlice = createSlice({
         pages: [], // Clear pages when switching views
       }
     ),
+    updateThreadAbuseFlaggedCount: (state, { payload }) => {
+      const { threadId, delta } = payload;
+      const thread = state.threadsById[threadId];
+      if (!thread) { return state; }
+      const currentCount = thread.abuseFlaggedCount || 0;
+      return {
+        ...state,
+        threadsById: {
+          ...state.threadsById,
+          [threadId]: {
+            ...thread,
+            abuseFlaggedCount: Math.max(0, currentCount + delta),
+          },
+        },
+      };
+    },
   },
 });
 
@@ -453,6 +500,7 @@ export const {
   sendAccountActivationEmailSuccess,
   toggleDeletedView,
   setDeletedView,
+  updateThreadAbuseFlaggedCount,
 } = threadsSlice.actions;
 
 export const threadsReducer = threadsSlice.reducer;


### PR DESCRIPTION
## Description

Fixes an issue where the discussion sidebar "Reported" badge was not updating correctly for abuse-flagged comments/responses.

## Fixes

* Added `updateThreadAbuseFlaggedCount` reducer to update a thread’s `abuseFlaggedCount` when comments/responses are flagged or unflagged.
* Updated `editComment` to dispatch thread count updates after successful abuse flag actions.
* Fixed thread merge logic in:

  * `fetchThreadsSuccess`
  * `fetchThreadSuccess`
  * `fetchThreadByDirectLinkSuccess`

  to preserve existing `abuseFlaggedCount` values when the API response does not include them.

## Result

* "Reported" badge updates immediately after flagging content.
* Badge persists correctly after page reloads.

## Ticket
[COSMO2-935](https://2u-internal.atlassian.net/browse/COSMO2-935)