### PR TITLE
fix: update role-based ban and unban permissions for discussion roles

### DIFF
--- a/src/discussions/common/BanModerationModals.jsx
+++ b/src/discussions/common/BanModerationModals.jsx
@@ -62,7 +62,7 @@ const BanModerationModals = ({
         closeButtonVariant="tertiary"
         confirmButtonVariant="danger"
         confirmButtonText={deleteConfirmText}
-        showBanCheckbox={enableDiscussionBan}
+        showBanCheckbox={showBanCheckboxOnDelete && enableDiscussionBan}
         banCheckboxLabel={intl.formatMessage(discussionMessages.banUserCheckbox)}
         isConfirmButtonPending={isProcessing}
       />
@@ -77,7 +77,7 @@ const BanModerationModals = ({
         closeButtonVariant="tertiary"
         confirmButtonVariant="danger"
         confirmButtonText={deleteConfirmText}
-        showBanCheckbox={enableDiscussionBan}
+        showBanCheckbox={showBanCheckboxOnDelete && enableDiscussionBan}
         banCheckboxLabel={intl.formatMessage(discussionMessages.banUserOrgCheckbox)}
         isConfirmButtonPending={isProcessing}
       />

--- a/src/discussions/learners/LearnerActionsDropdown.jsx
+++ b/src/discussions/learners/LearnerActionsDropdown.jsx
@@ -19,13 +19,14 @@ const LearnerActionsDropdown = ({
   userHasBulkDeletePrivileges,
   learnerBanInfo,
   contentStatus,
+  targetAuthorLabel,
 }) => {
   const buttonRef = useRef();
   const intl = useIntl();
   const [isOpen, open, close] = useToggle(false);
   const [target, setTarget] = useState(null);
   const [activeSubmenu, setActiveSubmenu] = useState(null);
-  const actions = useLearnerActions(userHasBulkDeletePrivileges, learnerBanInfo, contentStatus);
+  const actions = useLearnerActions(userHasBulkDeletePrivileges, learnerBanInfo, contentStatus, targetAuthorLabel);
 
   const handleActions = useCallback((action) => {
     const actionFunction = actionHandlers[action];
@@ -175,6 +176,7 @@ LearnerActionsDropdown.propTypes = {
     authorBanScope: PropTypes.string,
   }),
   contentStatus: PropTypes.string,
+  targetAuthorLabel: PropTypes.string,
 };
 
 LearnerActionsDropdown.defaultProps = {
@@ -182,6 +184,7 @@ LearnerActionsDropdown.defaultProps = {
   userHasBulkDeletePrivileges: false,
   learnerBanInfo: {},
   contentStatus: undefined,
+  targetAuthorLabel: null,
 };
 
 export default LearnerActionsDropdown;

--- a/src/discussions/learners/LearnerPostsView.jsx
+++ b/src/discussions/learners/LearnerPostsView.jsx
@@ -270,6 +270,16 @@ const LearnerPostsView = () => {
     };
   }, [bannedUsers, username]);
 
+  // Get the target user's author label from their first post
+  const targetAuthorLabel = useSelector(state => {
+    const firstThreadId = sortedPostsIds?.[0];
+    if (firstThreadId && state.threads.threadsById) {
+      const thread = state.threads.threadsById[firstThreadId];
+      return thread?.authorLabel || null;
+    }
+    return null;
+  });
+
   const postInstances = useMemo(() => (
     sortedPostsIds?.map((threadId, idx) => (
       <PostLink
@@ -355,6 +365,7 @@ const LearnerPostsView = () => {
                 userHasBulkDeletePrivileges={canAccessBulkActions}
                 learnerBanInfo={learnerBanInfo}
                 contentStatus={postFilter?.contentStatus}
+                targetAuthorLabel={targetAuthorLabel}
                 dropDownIconSize
               />
             </div>

--- a/src/discussions/learners/data/thunks.js
+++ b/src/discussions/learners/data/thunks.js
@@ -10,11 +10,13 @@ import {
 import {
   PostsStatusFilter, ThreadType,
 } from '../../../data/constants';
+import { updateAuthorBanStatus as updateCommentAuthorBanStatus } from '../../post-comments/data/slices';
 import {
   fetchLearnerThreadsRequest,
   fetchThreadsDenied,
   fetchThreadsFailed,
   fetchThreadsSuccess,
+  updateAuthorBanStatus as updateThreadAuthorBanStatus,
 } from '../../posts/data/slices';
 import { normaliseThreads } from '../../posts/data/thunks';
 import { getHttpErrorStatus } from '../../utils';
@@ -490,7 +492,8 @@ export function banUser(courseId, username, scope) {
       dispatch(banUserRequest());
       await banUserApi(courseId, username, scope);
       dispatch(banUserSuccess());
-      // Refresh the banned users list
+      dispatch(updateThreadAuthorBanStatus({ author: username, isBanned: true, banScope: scope }));
+      dispatch(updateCommentAuthorBanStatus({ author: username, isBanned: true, banScope: scope }));
       dispatch(fetchBannedUsers(courseId));
     } catch (error) {
       dispatch(banUserFailed());
@@ -533,7 +536,8 @@ export function unbanUser(courseId, username, scope) {
       dispatch(unbanUserRequest());
       await unbanUserApi(courseId, username, scope);
       dispatch(unbanUserSuccess());
-      // Refresh the banned users list
+      dispatch(updateThreadAuthorBanStatus({ author: username, isBanned: false, banScope: null }));
+      dispatch(updateCommentAuthorBanStatus({ author: username, isBanned: false, banScope: null }));
       dispatch(fetchBannedUsers(courseId));
     } catch (error) {
       dispatch(unbanUserFailed());

--- a/src/discussions/learners/utils.js
+++ b/src/discussions/learners/utils.js
@@ -13,6 +13,8 @@ import {
   selectUserCanBanAtCourseLevel,
   selectUserCanBanAtOrgLevel,
   selectUserHasModerationPrivileges,
+  selectUserIsStaff,
+  selectUserRoles,
 } from '../data/selectors';
 import { checkBanActionDisabled } from '../utils/banUtils';
 import { BAN_SCOPES } from './data/constants';
@@ -113,21 +115,42 @@ export function useLearnerActions(
   userHasBulkDeletePrivileges = false,
   learnerBanInfo = {},
   contentStatus = PostsStatusFilter.ACTIVE,
+  targetAuthorLabel = null,
 ) {
   const intl = useIntl();
   const enableDiscussionBan = useSelector(selectEnableDiscussionBan);
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
   const userCanBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
   const userCanBanAtOrgLevel = useSelector(selectUserCanBanAtOrgLevel);
+  const userRoles = useSelector(selectUserRoles);
+  const userIsGlobalStaff = useSelector(selectUserIsStaff);
 
   const actions = useMemo(() => {
     if (!userHasBulkDeletePrivileges || !userHasModerationPrivileges) {
       return [];
     }
 
+    // Check if user has discussion roles (Administrator or Moderator)
+    const roles = userRoles || [];
+    const userIsAdmin = roles.includes('Administrator');
+    const userIsModerator = roles.includes('Moderator');
+    const userHasDiscussionRole = userIsAdmin || userIsModerator;
+    const targetIsStaffBadge = targetAuthorLabel === 'Staff';
+    const targetIsDiscussionModerator = targetAuthorLabel === 'Moderator';
+    let shouldShowBanOption = true;
+
+    // Global Staff (no discussion role) cannot ban users with Staff or Moderator badges
+    if (userIsGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+      shouldShowBanOption = false;
+    }
+
+    // Discussion Moderator cannot ban another Discussion Moderator
+    if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+      shouldShowBanOption = false;
+    }
+
     return LEARNER_ACTIONS_LIST.filter(action => {
-      // Hide ban menu if feature flag is disabled OR user lacks course-level ban permissions
-      if (action.id === 'ban' && (!enableDiscussionBan || !userCanBanAtCourseLevel)) {
+      if (action.id === 'ban' && (!enableDiscussionBan || !userCanBanAtCourseLevel || !shouldShowBanOption)) {
         return false;
       }
 
@@ -253,6 +276,9 @@ export function useLearnerActions(
     contentStatus,
     enableDiscussionBan,
     intl,
+    userRoles,
+    userIsGlobalStaff,
+    targetAuthorLabel,
   ]);
 
   return actions;

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -17,7 +17,7 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import HTMLLoader from '../../../../components/HTMLLoader';
 import {
-  banUser, bulkDeleteUserPosts, unbanUser,
+  bulkDeleteUserPosts,
 } from '../../../../data/api/moderation';
 import {
   AvatarOutlineAndLabelColors,
@@ -43,6 +43,7 @@ import {
   selectShouldShowEmailConfirmation,
 } from '../../../data/selectors';
 import { muteUserThunk, unmuteUserThunk } from '../../../data/thunks';
+import { banUser, unbanUser } from '../../../learners/data/thunks';
 import discussionMessages from '../../../messages';
 // import { selectThread } from '../../../posts/data/selectors';
 import { fetchThread } from '../../../posts/data/thunks';
@@ -268,97 +269,45 @@ const Comment = ({
     }
   }, [author, courseId, threadId, dispatch, hideModal, enableDiscussionBan]);
 
-  const handleBanCourseConfirmation = useCallback(async () => {
-    // Defensive check - feature must be enabled
+  const createBanHandler = useCallback((actionFn, scope, actionName) => async () => {
     if (!enableDiscussionBan) {
-      logError('Ban operation attempted with feature disabled');
+      logError(`${actionName} operation attempted with feature disabled`);
       hideModal();
       return;
     }
-    // Defensive check - author must be defined
     if (!author) {
-      logError('Ban operation attempted without author');
+      logError(`${actionName} operation attempted without author`);
       hideModal();
       return;
     }
     try {
-      await banUser(courseId, author, 'course', 'Banned from course discussions');
+      await dispatch(actionFn(courseId, author, scope));
       hideModal();
-      dispatch(fetchThread(threadId, courseId));
     } catch (error) {
       const errorMsg = error?.message || String(error) || 'Unknown error';
-      logError(`Error banning user (course): ${errorMsg}`);
+      logError(`Error ${actionName.toLowerCase()} user (${scope}): ${errorMsg}`);
     }
-  }, [author, courseId, threadId, dispatch, hideModal, enableDiscussionBan]);
+  }, [author, courseId, dispatch, hideModal, enableDiscussionBan]);
 
-  const handleBanOrgConfirmation = useCallback(async () => {
-    // Defensive check - feature must be enabled
-    if (!enableDiscussionBan) {
-      logError('Ban operation attempted with feature disabled');
-      hideModal();
-      return;
-    }
-    // Defensive check - author must be defined
-    if (!author) {
-      logError('Ban operation attempted without author');
-      hideModal();
-      return;
-    }
-    try {
-      await banUser(courseId, author, 'organization', 'Banned from organization discussions');
-      hideModal();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      const errorMsg = error?.message || String(error) || 'Unknown error';
-      logError(`Error banning user (org): ${errorMsg}`);
-    }
-  }, [author, courseId, threadId, dispatch, hideModal, enableDiscussionBan]);
+  const handleBanCourseConfirmation = useCallback(
+    () => createBanHandler(banUser, 'course', 'Ban')(),
+    [createBanHandler],
+  );
 
-  const handleUnbanCourseConfirmation = useCallback(async () => {
-    // Defensive check - feature must be enabled
-    if (!enableDiscussionBan) {
-      logError('Unban operation attempted with feature disabled');
-      hideModal();
-      return;
-    }
-    // Defensive check - author must be defined
-    if (!author) {
-      logError('Unban operation attempted without author');
-      hideModal();
-      return;
-    }
-    try {
-      await unbanUser(courseId, author, 'course', 'Unbanned from course discussions');
-      hideModal();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      const errorMsg = error?.message || String(error) || 'Unknown error';
-      logError(`Error unbanning user (course): ${errorMsg}`);
-    }
-  }, [author, courseId, threadId, dispatch, hideModal, enableDiscussionBan]);
+  const handleBanOrgConfirmation = useCallback(
+    () => createBanHandler(banUser, 'organization', 'Ban')(),
+    [createBanHandler],
+  );
 
-  const handleUnbanOrgConfirmation = useCallback(async () => {
-    // Defensive check - feature must be enabled
-    if (!enableDiscussionBan) {
-      logError('Unban operation attempted with feature disabled');
-      hideModal();
-      return;
-    }
-    // Defensive check - author must be defined
-    if (!author) {
-      logError('Unban operation attempted without author');
-      hideModal();
-      return;
-    }
-    try {
-      await unbanUser(courseId, author, 'organization', 'Unbanned from organization discussions');
-      hideModal();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      const errorMsg = error?.message || String(error) || 'Unknown error';
-      logError(`Error unbanning user (org): ${errorMsg}`);
-    }
-  }, [author, courseId, threadId, dispatch, hideModal, enableDiscussionBan]);
+  const handleUnbanCourseConfirmation = useCallback(
+    () => createBanHandler(unbanUser, 'course', 'Unban')(),
+    [createBanHandler],
+  );
+
+  const handleUnbanOrgConfirmation = useCallback(
+    () => createBanHandler(unbanUser, 'organization', 'Unban')(),
+    [createBanHandler],
+  );
 
   // Mute modal handler - only for learners (staff use submenu)
   const showMuteModal = useCallback(() => {

--- a/src/discussions/post-comments/comments/comment/Reply.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.jsx
@@ -11,7 +11,7 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import HTMLLoader from '../../../../components/HTMLLoader';
 import {
-  banUser, bulkDeleteUserPosts, unbanUser,
+  bulkDeleteUserPosts,
 } from '../../../../data/api/moderation';
 import { AvatarOutlineAndLabelColors, ContentActions } from '../../../../data/constants';
 import {
@@ -25,6 +25,7 @@ import {
   selectIsUserBanned,
 } from '../../../data/selectors';
 import { muteUserThunk, unmuteUserThunk } from '../../../data/thunks';
+import { banUser, unbanUser } from '../../../learners/data/thunks';
 import discussionMessages from '../../../messages';
 import { selectAuthorAvatar } from '../../../posts/data/selectors';
 import { fetchThread } from '../../../posts/data/thunks';
@@ -145,45 +146,31 @@ const Reply = ({ responseId }) => {
     }
   }, [author, courseId, threadId, hideDeleteUserOrgConfirmation, enableDiscussionBan]);
 
-  const handleBanCourseConfirmation = useCallback(async (reason) => {
+  const executeBanAction = useCallback(async (actionFn, scope, hideFn) => {
     try {
-      await banUser(courseId, author, 'course', reason || 'Banned from course discussions');
-      hideBanCourseConfirmation();
-      dispatch(fetchThread(threadId, courseId));
+      await dispatch(actionFn(courseId, author, scope));
+      hideFn();
     } catch (error) {
       logError(error);
     }
-  }, [author, courseId, threadId, dispatch, hideBanCourseConfirmation]);
+  }, [author, courseId, dispatch]);
 
-  const handleBanOrgConfirmation = useCallback(async (reason) => {
-    try {
-      await banUser(courseId, author, 'organization', reason || 'Banned from organization discussions');
-      hideBanOrgConfirmation();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      logError(error);
-    }
-  }, [author, courseId, threadId, dispatch, hideBanOrgConfirmation]);
-
-  const handleUnbanCourseConfirmation = useCallback(async (reason) => {
-    try {
-      await unbanUser(courseId, author, 'course', reason || 'Unbanned from course discussions');
-      hideUnbanCourseConfirmation();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      logError(error);
-    }
-  }, [author, courseId, threadId, dispatch, hideUnbanCourseConfirmation]);
-
-  const handleUnbanOrgConfirmation = useCallback(async (reason) => {
-    try {
-      await unbanUser(courseId, author, 'organization', reason || 'Unbanned from organization discussions');
-      hideUnbanOrgConfirmation();
-      dispatch(fetchThread(threadId, courseId));
-    } catch (error) {
-      logError(error);
-    }
-  }, [author, courseId, threadId, dispatch, hideUnbanOrgConfirmation]);
+  const handleBanCourseConfirmation = useCallback(
+    () => executeBanAction(banUser, 'course', hideBanCourseConfirmation),
+    [executeBanAction, hideBanCourseConfirmation],
+  );
+  const handleBanOrgConfirmation = useCallback(
+    () => executeBanAction(banUser, 'organization', hideBanOrgConfirmation),
+    [executeBanAction, hideBanOrgConfirmation],
+  );
+  const handleUnbanCourseConfirmation = useCallback(
+    () => executeBanAction(unbanUser, 'course', hideUnbanCourseConfirmation),
+    [executeBanAction, hideUnbanCourseConfirmation],
+  );
+  const handleUnbanOrgConfirmation = useCallback(
+    () => executeBanAction(unbanUser, 'organization', hideUnbanOrgConfirmation),
+    [executeBanAction, hideUnbanOrgConfirmation],
+  );
 
   // Mute modal handler - only for learners (staff use submenu)
   const showMuteModal = useCallback(() => {

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -272,6 +272,20 @@ const commentsSlice = createSlice({
         draftResponses: payload,
       }
     ),
+    // Update ban status for all comments by a specific author
+    updateAuthorBanStatus: (state, { payload }) => {
+      const { author, isBanned, banScope } = payload;
+      // simplified: concise reduce pattern that only updates matching authors
+      const updatedCommentsById = Object.keys(state.commentsById).reduce((acc, commentId) => {
+        const comment = state.commentsById[commentId];
+        acc[commentId] = comment.author === author
+          ? { ...comment, isAuthorBanned: isBanned, authorBanScope: banScope }
+          : comment;
+        return acc;
+      }, {});
+
+      return { ...state, commentsById: updatedCommentsById };
+    },
   },
 });
 
@@ -299,6 +313,7 @@ export const {
   setCommentSortOrder,
   setDraftComments,
   setDraftResponses,
+  updateAuthorBanStatus,
 } = commentsSlice.actions;
 
 export const commentsReducer = commentsSlice.reducer;

--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -456,6 +456,21 @@ const threadsSlice = createSlice({
         },
       };
     },
+
+    // Update ban status for all threads by a specific author
+    updateAuthorBanStatus: (state, { payload }) => {
+      const { author, isBanned, banScope } = payload;
+      // simplified: concise reduce pattern that only updates matching authors
+      const updatedThreadsById = Object.keys(state.threadsById).reduce((acc, threadId) => {
+        const thread = state.threadsById[threadId];
+        acc[threadId] = thread.author === author
+          ? { ...thread, isAuthorBanned: isBanned, authorBanScope: banScope }
+          : thread;
+        return acc;
+      }, {});
+
+      return { ...state, threadsById: updatedThreadsById };
+    },
   },
 });
 
@@ -501,6 +516,7 @@ export const {
   toggleDeletedView,
   setDeletedView,
   updateThreadAbuseFlaggedCount,
+  updateAuthorBanStatus,
 } = threadsSlice.actions;
 
 export const threadsReducer = threadsSlice.reducer;

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -30,6 +30,7 @@ import {
   selectContentCreationRateLimited,
   selectIsUserBanned,
   selectShouldShowEmailConfirmation,
+  selectUserCanBanAtCourseLevel,
   selectUserHasModerationPrivileges,
 } from '../../data/selectors';
 import { muteUserThunk, unmuteUserThunk } from '../../data/thunks';
@@ -90,6 +91,23 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
   const [isLearnerMuting, showLearnerMuteModal, hideLearnerMuteModal] = useToggle(false);
   const [isLearnerUnmuting, showLearnerUnmuteModal, hideLearnerUnmuteModal] = useToggle(false);
   const userHasModerationPrivileges = useSelector(selectUserHasModerationPrivileges);
+  const canBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
+  const userRoles = useSelector(state => state.config.userRoles);
+  const isGlobalStaff = useSelector(state => state.config.isUserAdmin);
+
+  // Compute shouldShowBanOption per authority table
+  const userIsAdmin = (userRoles || []).includes('Administrator');
+  const userIsModerator = (userRoles || []).includes('Moderator');
+  const userHasDiscussionRole = userIsAdmin || userIsModerator;
+  const targetIsStaffBadge = authorLabel === 'Staff';
+  const targetIsDiscussionModerator = authorLabel === 'Moderator';
+  let shouldShowBanOption = true;
+  if (isGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+    shouldShowBanOption = false;
+  }
+  if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+    shouldShowBanOption = false;
+  }
   const shouldShowEmailConfirmation = useSelector(selectShouldShowEmailConfirmation);
   const enableDiscussionBan = useSelector(state => state.config.enableDiscussionBan);
   const contentCreationRateLimited = useSelector(selectContentCreationRateLimited);
@@ -508,7 +526,7 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         onUnbanOrg={handleUnbanOrgConfirmation}
         isProcessing={isProcessing}
         enableDiscussionBan={enableDiscussionBan}
-        showBanCheckboxOnDelete={userHasModerationPrivileges}
+        showBanCheckboxOnDelete={shouldShowBanOption && canBanAtCourseLevel && enableDiscussionBan}
         deleteTitle={intl.formatMessage(messages.deletePostTitle)}
         deleteDescription={intl.formatMessage(messages.deletePostDescription)}
         deleteConfirmText={intl.formatMessage(messages.deleteConfirmationDelete)}

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -98,14 +98,27 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
   // Compute shouldShowBanOption per authority table
   const userIsAdmin = (userRoles || []).includes('Administrator');
   const userIsModerator = (userRoles || []).includes('Moderator');
-  const userHasDiscussionRole = userIsAdmin || userIsModerator;
+  const userIsDiscussionAdmin = (userRoles || []).includes('Discussion Admin');
+  const userHasDiscussionRole = userIsAdmin || userIsModerator || userIsDiscussionAdmin;
   const targetIsStaffBadge = authorLabel === 'Staff';
   const targetIsDiscussionModerator = authorLabel === 'Moderator';
+  const targetIsDiscussionAdmin = authorLabel === 'Discussion Admin';
   let shouldShowBanOption = true;
-  if (isGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+
+  // Global Staff without discussion role cannot ban  Moderator
+  if (
+    isGlobalStaff
+    && !userHasDiscussionRole
+    && (targetIsStaffBadge || targetIsDiscussionModerator || targetIsDiscussionAdmin)
+  ) {
     shouldShowBanOption = false;
   }
-  if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+  // Discussion Moderator cannot ban another Moderator or Admin
+  if (userIsModerator && !userIsAdmin && (targetIsDiscussionModerator || targetIsDiscussionAdmin)) {
+    shouldShowBanOption = false;
+  }
+  // Discussion Admin cannot ban another Admin or Moderator
+  if (userIsDiscussionAdmin && (targetIsDiscussionAdmin || targetIsDiscussionModerator)) {
     shouldShowBanOption = false;
   }
   const shouldShowEmailConfirmation = useSelector(selectShouldShowEmailConfirmation);

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -374,6 +374,7 @@ export function useActions(contentType, id, hasModerationPrivileges) {
   // Check if user can perform course-level and org-level bans
   const canBanAtCourseLevel = useSelector(selectUserCanBanAtCourseLevel);
   const canBanAtOrgLevel = useSelector(selectUserCanBanAtOrgLevel);
+  const userRoles = useSelector(state => state.config.userRoles);
   // Group TA - has limited permissions within their group
   const isUserGroupTA = useSelector(state => state.config.isGroupTa);
   // Course Staff/Admin - NO discussion privileges (treated as learners)
@@ -488,6 +489,26 @@ export function useActions(contentType, id, hasModerationPrivileges) {
     const isOwnContent = (currentUser && baseContent?.author && currentUser === baseContent.author)
       || (currentUserId && baseContent?.authorId && String(currentUserId) === String(baseContent.authorId));
 
+    // Check if user has discussion roles (Administrator or Moderator)
+    const roles = userRoles || [];
+    const userIsAdmin = roles.includes('Administrator');
+    const userIsModerator = roles.includes('Moderator');
+    const userHasDiscussionRole = userIsAdmin || userIsModerator;
+    const targetIsStaffBadge = baseContent?.authorLabel === 'Staff';
+    const targetIsDiscussionModerator = baseContent?.authorLabel === 'Moderator';
+
+    let shouldShowBanOption = true;
+
+    // Global Staff (no discussion role) cannot ban users with Staff or Moderator badges
+    if (isGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+      shouldShowBanOption = false;
+    }
+
+    // Discussion Moderator cannot ban another Discussion Moderator
+    if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+      shouldShowBanOption = false;
+    }
+
     const filteredActions = ACTIONS_LIST.filter(
       ({
         action,
@@ -495,8 +516,7 @@ export function useActions(contentType, id, hasModerationPrivileges) {
         hasSubmenu = false,
         id: actionId,
       }) => {
-        // Hide ban menu if feature flag is disabled OR user lacks course-level ban permissions
-        if (actionId === 'ban' && (!enableDiscussionBan || !canBanAtCourseLevel)) {
+        if (actionId === 'ban' && (!enableDiscussionBan || !canBanAtCourseLevel || !shouldShowBanOption)) {
           return false;
         }
         // For items with submenus, skip permission check on parent item
@@ -663,6 +683,7 @@ export function useActions(contentType, id, hasModerationPrivileges) {
     hasDiscussionModeratorPrivileges,
     isUserGroupTA,
     contentType,
+    userRoles,
   ]);
 
   return actions;


### PR DESCRIPTION
### Description
The current banning and unbanning behavior does not fully align with the expected role-based permission hierarchy for Global Staff, Discussion Admins, and Discussion Moderators.

This update introduces role-based permission handling for both ban and unban actions to ensure moderation behavior matches the expected access rules and prevents unauthorized actions.

### Expected Permission Rules
#### Global Staff
  - Can be banned by users with discussion permissions
  - Cannot ban another Global Staff user unless they also have Discussion Admin or Discussion Moderator permissions
  - If assigned Discussion Admin permissions, they can only ban Discussion Moderators
#### Discussion Admin
  - Can ban and unban Discussion Moderators
  - Can ban and unban Global Staff users
  - Cannot be banned or unbanned by Discussion Moderators
#### Discussion Moderator
  - Can ban and unban Global Staff users
  - Cannot ban or unban Discussion Admins
  
 ### Ticket
[ Cosmo2-963](https://2u-internal.atlassian.net/browse/COSMO2-963)