### PR TITLE
fix: prevent reported badge from rendering stray 0 for unreported threads

### DIFF
--- a/src/discussions/posts/data/slices.js
+++ b/src/discussions/posts/data/slices.js
@@ -107,7 +107,7 @@ const threadsSlice = createSlice({
           ...thread,
           abuseFlaggedCount: thread.abuseFlaggedCount != null
             ? thread.abuseFlaggedCount
-            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+            : mergedThreadsById[id]?.abuseFlaggedCount,
         };
       });
       newState.threadsById = mergedThreadsById;
@@ -148,7 +148,7 @@ const threadsSlice = createSlice({
           ...thread,
           abuseFlaggedCount: thread.abuseFlaggedCount != null
             ? thread.abuseFlaggedCount
-            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+            : mergedThreadsById[id]?.abuseFlaggedCount,
         };
       });
       return {
@@ -166,7 +166,7 @@ const threadsSlice = createSlice({
           ...thread,
           abuseFlaggedCount: thread.abuseFlaggedCount != null
             ? thread.abuseFlaggedCount
-            : (mergedThreadsById[id]?.abuseFlaggedCount || 0),
+            : mergedThreadsById[id]?.abuseFlaggedCount,
         };
       });
       return {

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -76,7 +76,7 @@ const PostLink = ({
   })();
   const showAnsweredBadge = hasEndorsed && type === ThreadType.QUESTION;
   const authorLabelColor = AvatarOutlineAndLabelColors[authorLabel];
-  const canSeeReportedBadge = abuseFlagged || abuseFlaggedCount;
+  const canSeeReportedBadge = !!(abuseFlagged || abuseFlaggedCount);
   const isPostRead = read || (!read && commentCount !== unreadCommentCount);
   const shouldUseSingleLineAuthorRole = ['learners', 'posts', 'my-posts'].includes(page);
 


### PR DESCRIPTION
### Description

Fixed an issue where unreported threads rendered a stray `0` instead of hiding the "Reported" badge.

### Changes

* Removed `|| 0` fallback for `abuseFlaggedCount` in `slices.js`.
* Updated `canSeeReportedBadge` in `PostLink.jsx` to return a strict boolean using:

  ```js
  !!(abuseFlagged || abuseFlaggedCount)
  ```