### PR TITLE
fix: update discussion role label mapping and serializer handling

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -101,9 +101,16 @@ export const RequestStatus = {
  * @enum {string}
  */
 export const AvatarOutlineAndLabelColors = {
-  Staff: 'staff-color',
+  // New role names
+  'Global Staff': 'staff-color',
+  'Course Staff': 'staff-color',
+  'Course Instructor': 'staff-color',
+  Administrator: 'TA-color',
   Moderator: 'TA-color',
   'Community TA': 'TA-color',
+  'Group Moderator': 'TA-color',
+  // Legacy mappings for backward compatibility
+  Staff: 'staff-color',
 };
 
 /**

--- a/src/discussions/common/AlertBanner.jsx
+++ b/src/discussions/common/AlertBanner.jsx
@@ -35,8 +35,11 @@ const AlertBanner = ({
   const canSeeLastEditOrClosedAlert = (userHasModerationPrivileges || userIsGroupTa
     || userIsGlobalStaff || userIsContentAuthor
   );
-  const editByLabelColor = AvatarOutlineAndLabelColors[editByLabel];
-  const closedByLabelColor = AvatarOutlineAndLabelColors[closedByLabel];
+  // Extract first role for color lookup (handles comma-separated multi-role strings)
+  const firstEditByRole = editByLabel?.split(',')[0]?.trim();
+  const firstClosedByRole = closedByLabel?.split(',')[0]?.trim();
+  const editByLabelColor = AvatarOutlineAndLabelColors[firstEditByRole];
+  const closedByLabelColor = AvatarOutlineAndLabelColors[firstClosedByRole];
 
   return (
     <>

--- a/src/discussions/common/AuthorLabel.jsx
+++ b/src/discussions/common/AuthorLabel.jsx
@@ -10,10 +10,10 @@ import * as timeago from 'timeago.js';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { Routes } from '../../data/constants';
+import { AvatarOutlineAndLabelColors, Routes } from '../../data/constants';
 import { useLearnerStatus } from '../data/hooks/useLearnerStatus';
 import messages from '../messages';
-import { getAuthorLabel } from '../utils';
+import { getAuthorLabel, getAuthorLabels } from '../utils';
 import DiscussionContext from './context';
 import timeLocale from './time-locale';
 
@@ -33,8 +33,13 @@ const AuthorLabel = ({
   timeago.register('time-locale', timeLocale);
   const intl = useIntl();
   const { courseId, enableInContextSidebar } = useContext(DiscussionContext);
-  const { icon, authorLabelMessage } = useMemo(
+  const { authorLabelMessage } = useMemo(
     () => getAuthorLabel(intl, authorLabel),
+    [authorLabel, intl],
+  );
+  // All matched roles for multi-role display
+  const authorRolesList = useMemo(
+    () => getAuthorLabels(intl, authorLabel),
     [authorLabel, intl],
   );
   const { isNewLearner, isRegularLearner } = useLearnerStatus(
@@ -51,12 +56,14 @@ const AuthorLabel = ({
     return personalMutedUsers.includes(author) || courseWideMutedUsers.includes(author);
   }, [author, personalMutedUsers, courseWideMutedUsers]);
 
+  // For multi-role display, avoid applying one shared color to the whole row.
+  const appliedLabelColor = authorRolesList.length > 1 ? '' : labelColor;
+
   const isRetiredUser = author ? author.startsWith('retired__user') : false;
-  const showTextPrimary = !authorLabelMessage && !isRetiredUser && !alert;
   const className = classNames(
     'd-flex align-items-center',
     { 'mb-0.5': !postOrComment },
-    labelColor,
+    appliedLabelColor,
   );
 
   // Check if user is banned from postData
@@ -68,13 +75,6 @@ const AuthorLabel = ({
     && author !== intl.formatMessage(messages.anonymous)
     && !enableInContextSidebar
   );
-  const canDisplayLearnerRole = Boolean(
-    author
-    && !isRetiredUser
-    && author !== intl.formatMessage(messages.anonymous),
-  );
-
-  const hasRecognizedAuthorRole = Boolean(authorLabelMessage && icon);
 
   const authorName = useMemo(
     () => (
@@ -82,6 +82,7 @@ const AuthorLabel = ({
         className={classNames('mr-1.5 font-style font-weight-500 author-name', {
           'text-gray-700': isRetiredUser || !author,
           'text-primary-500': !authorLabelMessage && !isRetiredUser && author,
+          [labelColor]: !!authorLabelMessage && !isRetiredUser && author && !!labelColor,
         })}
         role="heading"
         aria-level="2"
@@ -89,7 +90,7 @@ const AuthorLabel = ({
         {isRetiredUser ? '[Deactivated]' : (author || '[Deleted User]')}
       </span>
     ),
-    [author, authorLabelMessage, isRetiredUser],
+    [author, authorLabelMessage, isRetiredUser, labelColor],
   );
 
   const createLearnerMessage = useCallback(
@@ -179,7 +180,9 @@ const AuthorLabel = ({
 
   const roleContents = useMemo(
     () => {
-      if (hasRecognizedAuthorRole) {
+      if (authorRolesList.length > 0) {
+        const firstRole = authorRolesList[0].role;
+
         return (
           <OverlayTrigger
             placement={authorToolTip ? 'top' : 'right'}
@@ -188,11 +191,13 @@ const AuthorLabel = ({
                 id={
                   authorToolTip
                     ? `endorsed-by-${author}-tooltip`
-                    : `${authorLabel}-label-tooltip`
+                    : `${firstRole.toLowerCase().replace(/\s+/g, '-')}-label-tooltip`
                 }
               >
                 <>
-                  {authorToolTip ? author : authorLabel}
+                  {authorToolTip
+                    ? author
+                    : authorRolesList.map(role => role.authorLabelMessage).join(', ')}
                   <br />
                   {intl.formatMessage(messages.authorAdminDescription)}
                 </>
@@ -200,40 +205,45 @@ const AuthorLabel = ({
             )}
             trigger={['hover', 'focus']}
           >
-            <div className={classNames('d-flex flex-row align-items-center')}>
-              <Icon
-                style={{
-                  width: '1rem',
-                  height: '1rem',
-                }}
-                src={icon}
-                data-testid="author-icon"
-              />
-              <span
-                className={classNames('mr-1.5 font-style font-weight-500', {
-                  'text-primary-500': showTextPrimary,
-                  'text-gray-700': isRetiredUser,
-                })}
-                style={{ marginLeft: '2px' }}
-              >
-                {authorLabelMessage}
-              </span>
+            <div className="d-flex flex-row align-items-center author-role-label">
+              {authorRolesList.map((roleEntry, index) => (
+                <React.Fragment key={roleEntry.role}>
+                  {index > 0 && (
+                    <span className="font-style font-weight-500" style={{ margin: '0 2px' }}>,</span>
+                  )}
+                  <span
+                    className={classNames(
+                      'd-flex flex-row align-items-center',
+                      AvatarOutlineAndLabelColors[roleEntry.role]
+                      && `text-${AvatarOutlineAndLabelColors[roleEntry.role]}`,
+                    )}
+                  >
+                    <Icon
+                      style={{
+                        width: '1rem',
+                        height: '1rem',
+                        flexShrink: 0,
+                        marginLeft: index === 0 ? '0' : '2px',
+                      }}
+                      src={roleEntry.icon}
+                      data-testid="author-icon"
+                    />
+                    <span
+                      className="font-style font-weight-500"
+                      style={{
+                        marginLeft: '2px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {roleEntry.authorLabelMessage}
+                    </span>
+                  </span>
+                </React.Fragment>
+              ))}
             </div>
           </OverlayTrigger>
-        );
-      }
-
-      if (canDisplayLearnerRole) {
-        return (
-          <span
-            className={classNames('font-style font-weight-400', {
-              'text-white': alert,
-              'text-gray-600': !alert,
-            })}
-            style={{ fontSize: '12px', lineHeight: '16px' }}
-          >
-            {intl.formatMessage(messages.learnerMessage)}
-          </span>
         );
       }
 
@@ -241,16 +251,9 @@ const AuthorLabel = ({
     },
     [
       author,
-      authorLabel,
-      authorLabelMessage,
+      authorRolesList,
       authorToolTip,
-      canDisplayLearnerRole,
-      hasRecognizedAuthorRole,
-      icon,
       intl,
-      isRetiredUser,
-      showTextPrimary,
-      alert,
     ],
   );
 
@@ -288,7 +291,7 @@ const AuthorLabel = ({
   if (singleLine) {
     return (
       <div className={className}>
-        <div className={classNames('d-flex align-items-center flex-nowrap', labelColor)}>
+        <div className={classNames('d-flex align-items-center flex-nowrap', appliedLabelColor)} style={{ minWidth: 0, overflow: 'hidden' }}>
           {showUserNameAsLink ? learnerPostsLink : authorName}
           {roleBeforeTimestamp && roleContents}
           {timestamp}
@@ -301,12 +304,12 @@ const AuthorLabel = ({
 
   return showUserNameAsLink ? (
     <div className={`${className} flex-wrap`}>
-      <div className="d-flex flex-column w-100">
-        <div className={classNames('d-flex align-items-center', labelColor)}>
+      <div className="d-flex flex-column w-100" style={{ minWidth: 0 }}>
+        <div className={classNames('d-flex align-items-center', appliedLabelColor)} style={{ minWidth: 0, overflow: 'hidden' }}>
           {learnerPostsLink}
           {timestamp}
         </div>
-        <div className={classNames('d-flex align-items-center', labelColor)}>
+        <div className={classNames('d-flex align-items-center', appliedLabelColor)} style={{ minWidth: 0, overflow: 'hidden' }}>
           {roleContents}
           {bannedIndicator}
         </div>
@@ -315,12 +318,12 @@ const AuthorLabel = ({
     </div>
   ) : (
     <div className={`${className} flex-wrap`}>
-      <div className="d-flex flex-column w-100">
-        <div className={classNames('d-flex align-items-center', labelColor)}>
+      <div className="d-flex flex-column w-100" style={{ minWidth: 0 }}>
+        <div className={classNames('d-flex align-items-center', appliedLabelColor)} style={{ minWidth: 0, overflow: 'hidden' }}>
           {authorName}
           {timestamp}
         </div>
-        <div className={classNames('d-flex align-items-center', labelColor)}>
+        <div className={classNames('d-flex align-items-center', appliedLabelColor)} style={{ minWidth: 0, overflow: 'hidden' }}>
           {roleContents}
           {bannedIndicator}
         </div>
@@ -332,7 +335,7 @@ const AuthorLabel = ({
 
 AuthorLabel.propTypes = {
   author: PropTypes.string,
-  authorLabel: PropTypes.string,
+  authorLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   linkToProfile: PropTypes.bool,
   labelColor: PropTypes.string,
   alert: PropTypes.bool,

--- a/src/discussions/common/AuthorLabel.test.jsx
+++ b/src/discussions/common/AuthorLabel.test.jsx
@@ -74,7 +74,7 @@ describe('Author label', () => {
     ['ta_user', 'Community TA', true, 'text-TA-color'],
     ['moderator_user', 'Moderator', true, 'text-TA-color'],
     ['retired__user', null, false, ''],
-    ['staff_user', 'Staff', true, 'text-staff-color'],
+    ['staff_user', 'Global Staff', true, 'text-staff-color'],
     ['learner_user', null, false, ''],
   ])('for %s', (author, authorLabel, linkToProfile, labelColor) => {
     it(
@@ -115,16 +115,16 @@ describe('Author label', () => {
       async () => {
         renderComponent(author, authorLabel, linkToProfile, labelColor);
         const roleLabelByAuthorLabel = {
-          'Community TA': 'CTA',
-          Moderator: 'TA',
-          Staff: 'Staff',
+          'Community TA': 'Community TA',
+          Moderator: 'Discussion Moderator',
+          Staff: 'Global Staff',
         };
         const expectedRoleLabel = roleLabelByAuthorLabel[authorLabel];
 
         if (linkToProfile && expectedRoleLabel) {
           expect(screen.getByText(expectedRoleLabel)).toBeInTheDocument();
         } else {
-          expect(screen.queryByText('CTA')).not.toBeInTheDocument();
+          expect(screen.queryByText('Community TA')).not.toBeInTheDocument();
           expect(screen.queryByText('TA')).not.toBeInTheDocument();
           expect(screen.queryByText('Staff')).not.toBeInTheDocument();
         }
@@ -238,7 +238,7 @@ describe('Author label', () => {
       it('should not display regular learner message in sidebar', () => {
         const postData = { learner_status: 'regular' };
         renderComponent('testuser', null, false, '', false, postData, false);
-        expect(screen.getByText('Learner')).toBeInTheDocument();
+        expect(screen.queryByText('Learner')).not.toBeInTheDocument();
         expect(screen.queryByText('👋 Hi, I am a new learner')).not.toBeInTheDocument();
       });
 
@@ -269,7 +269,7 @@ describe('Author label', () => {
         </IntlProvider>,
       );
 
-      const roleLabel = screen.getByText('Staff');
+      const roleLabel = screen.getByText('Global Staff');
       const timestamp = document.querySelector('.post-summary-timestamp');
 
       expect(timestamp).toBeInTheDocument();
@@ -300,7 +300,7 @@ describe('Author label', () => {
       const authorElement = container.querySelector('[role=heading]');
       expect(authorElement).toHaveTextContent('[Deleted User]');
       // Should still show the staff label even though author is null
-      expect(container).toHaveTextContent('Staff');
+      expect(container).toHaveTextContent('Global Staff');
     });
 
     it('should not display learner messages when author is null', () => {

--- a/src/discussions/data/hooks/useLearnerStatus.js
+++ b/src/discussions/data/hooks/useLearnerStatus.js
@@ -9,15 +9,17 @@ import { useMemo } from 'react';
  * @param {Object} postData - The thread or comment data from the API that includes learner_status field
  * @param {string} author - The username of the author; used to check for anonymous and retired users
  * to suppress learner messages
- * @param {string} authorLabel - The author's role label (Staff, Moderator, etc.)
+ * @param {string|string[]|null} authorLabel - The author's role label(s)
  * @returns {Object} - { isNewLearner: boolean, isRegularLearner: boolean }
  */
 export const useLearnerStatus = (postData, author, authorLabel) => useMemo(() => {
+  const hasAuthorRole = Array.isArray(authorLabel) ? authorLabel.length > 0 : Boolean(authorLabel);
+
   // Users with special roles (Staff, Moderator, Community TA) should not display learner messages
   // Anonymous, retired, and deleted users should also not display learner messages
   if (
     !author
-    || authorLabel
+    || hasAuthorRole
     || author === 'anonymous'
     || author.startsWith('retired__user')
   ) {

--- a/src/discussions/learners/data/thunks.js
+++ b/src/discussions/learners/data/thunks.js
@@ -555,11 +555,20 @@ export function unbanUser(courseId, username, scope) {
  * @returns {(function(*): Promise<void>)|*}
  */
 export function deleteUserActivity(courseId, username, scope, shouldBanUser = false) {
-  return async (dispatch) => {
+  return async (dispatch, getState) => {
     try {
       dispatch(deleteUserActivityRequest());
       const response = await bulkDeleteUserActivity(courseId, username, scope, shouldBanUser);
       dispatch(deleteUserActivitySuccess(camelCaseObject(response)));
+
+      // Refresh learner stats list so deleted counts update immediately
+      const state = getState();
+      dispatch(fetchLearners(courseId, {
+        orderBy: state.learners?.sortedBy,
+        page: 1,
+        usernameSearch: state.learners?.usernameSearch,
+      }));
+
       // Refresh banned users list if user was banned
       if (shouldBanUser) {
         dispatch(fetchBannedUsers(courseId));

--- a/src/discussions/learners/utils.js
+++ b/src/discussions/learners/utils.js
@@ -16,6 +16,7 @@ import {
   selectUserIsStaff,
   selectUserRoles,
 } from '../data/selectors';
+import { getAuthorRoles } from '../utils';
 import { checkBanActionDisabled } from '../utils/banUtils';
 import { BAN_SCOPES } from './data/constants';
 import messages from './messages';
@@ -135,17 +136,35 @@ export function useLearnerActions(
     const userIsAdmin = roles.includes('Administrator');
     const userIsModerator = roles.includes('Moderator');
     const userHasDiscussionRole = userIsAdmin || userIsModerator;
-    const targetIsStaffBadge = targetAuthorLabel === 'Staff';
-    const targetIsDiscussionModerator = targetAuthorLabel === 'Moderator';
+
+    // Check target user's role badges (handle both new and legacy label formats)
+    const targetRoles = getAuthorRoles(targetAuthorLabel);
+
+    const targetIsGlobalStaff = targetRoles.includes('Global Staff')
+      || targetRoles.includes('Staff');
+
+    const targetIsDiscussionAdmin = targetRoles.includes('Administrator');
+
+    const targetIsDiscussionModerator = targetRoles.includes('Moderator');
+
+    const targetHasPrivilegedRole = targetIsGlobalStaff
+      || targetIsDiscussionAdmin
+      || targetIsDiscussionModerator;
+
     let shouldShowBanOption = true;
 
-    // Global Staff (no discussion role) cannot ban users with Staff or Moderator badges
-    if (userIsGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+    // Global Staff (no discussion role) cannot ban users with privileged roles
+    if (userIsGlobalStaff && !userHasDiscussionRole && targetHasPrivilegedRole) {
       shouldShowBanOption = false;
     }
 
-    // Discussion Moderator cannot ban another Discussion Moderator
-    if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+    // Discussion Moderator cannot ban Discussion Admin or another Discussion Moderator
+    if (userIsModerator && !userIsAdmin && (targetIsDiscussionAdmin || targetIsDiscussionModerator)) {
+      shouldShowBanOption = false;
+    }
+
+    // Discussion Admin cannot ban another Discussion Admin
+    if (userIsAdmin && targetIsDiscussionAdmin) {
       shouldShowBanOption = false;
     }
 

--- a/src/discussions/messages.js
+++ b/src/discussions/messages.js
@@ -358,18 +358,38 @@ const messages = defineMessages({
   },
   authorLabelStaff: {
     id: 'discussions.authors.label.staff',
-    defaultMessage: 'Staff',
-    description: 'A label for staff users displayed next to their username.',
+    defaultMessage: 'Global Staff',
+    description: 'A label for global staff users displayed next to their username.',
   },
   authorLabelModerator: {
     id: 'discussions.authors.label.moderator',
-    defaultMessage: 'TA',
+    defaultMessage: 'Discussion Moderator',
     description: 'A label for moderators displayed next to their username.',
+  },
+  authorLabelAdministrator: {
+    id: 'discussions.authors.label.administrator',
+    defaultMessage: 'Discussion Administrator',
+    description: 'A label for administrators displayed next to their username.',
   },
   authorLabelTA: {
     id: 'discussions.authors.label.ta',
-    defaultMessage: 'CTA',
+    defaultMessage: 'Community TA',
     description: 'A label for community TAs displayed next to their username.',
+  },
+  authorLabelCourseStaff: {
+    id: 'discussions.authors.label.courseStaff',
+    defaultMessage: 'Course Staff',
+    description: 'A label for course staff displayed next to their username.',
+  },
+  authorLabelCourseInstructor: {
+    id: 'discussions.authors.label.courseInstructor',
+    defaultMessage: 'Course Instructor',
+    description: 'A label for course instructors displayed next to their username.',
+  },
+  authorLabelGroupModerator: {
+    id: 'discussions.authors.label.groupModerator',
+    defaultMessage: 'Group Moderator',
+    description: 'A label for group moderators displayed next to their username.',
   },
   authorLabelBanned: {
     id: 'discussions.authors.label.banned',

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -78,10 +78,37 @@ const Comment = ({
 }) => {
   const comment = useSelector(selectCommentOrResponseById(commentId));
   const {
-    id, parentId, childCount, abuseFlagged, endorsed, threadId, endorsedAt, endorsedBy, endorsedByLabel, renderedBody,
-    voted, following, voteCount, authorLabel, author, createdAt, lastEdit, rawBody, closed, closedBy, closeReason,
-    editByLabel, closedByLabel, users: postUsers, isDeleted, deletedBy, deletedByLabel, is_spam: isSpam,
+    id,
+    parentId,
+    childCount,
+    abuseFlagged,
+    endorsed,
+    threadId,
+    endorsedAt,
+    endorsedBy,
+    endorsedByLabel,
+    renderedBody,
+    voted,
+    following,
+    voteCount,
+    authorLabel: rawAuthorLabel,
+    authorLabels,
+    author,
+    createdAt,
+    lastEdit,
+    rawBody,
+    closed,
+    closedBy,
+    closeReason,
+    editByLabel,
+    closedByLabel,
+    users: postUsers,
+    isDeleted,
+    deletedBy,
+    deletedByLabel,
+    is_spam: isSpam,
   } = comment;
+  const authorLabel = (authorLabels && authorLabels.length > 0) ? authorLabels : rawAuthorLabel;
   const intl = useIntl();
   const hasChildren = childCount > 0;
   const isNested = Boolean(parentId);

--- a/src/discussions/post-comments/comments/comment/CommentHeader.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentHeader.jsx
@@ -11,6 +11,7 @@ import { AvatarOutlineAndLabelColors } from '../../../../data/constants';
 import { AuthorLabel } from '../../../common';
 import { useAlertBannerVisible } from '../../../data/hooks';
 import { selectAuthorAvatar } from '../../../posts/data/selectors';
+import { getAuthorRoles } from '../../../utils';
 
 const CommentHeader = ({
   author,
@@ -22,7 +23,8 @@ const CommentHeader = ({
   postUsers,
   postData,
 }) => {
-  const colorClass = AvatarOutlineAndLabelColors[authorLabel];
+  const firstRole = getAuthorRoles(authorLabel)[0];
+  const colorClass = AvatarOutlineAndLabelColors[firstRole];
   const hasAnyAlert = useAlertBannerVisible({
     author,
     abuseFlagged,
@@ -66,7 +68,7 @@ const CommentHeader = ({
 
 CommentHeader.propTypes = {
   author: PropTypes.string.isRequired,
-  authorLabel: PropTypes.string,
+  authorLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   abuseFlagged: PropTypes.bool.isRequired,
   closed: PropTypes.bool,
   createdAt: PropTypes.string.isRequired,

--- a/src/discussions/post-comments/comments/comment/Reply.jsx
+++ b/src/discussions/post-comments/comments/comment/Reply.jsx
@@ -31,6 +31,7 @@ import { selectAuthorAvatar } from '../../../posts/data/selectors';
 import { fetchThread } from '../../../posts/data/thunks';
 import DeleteWithBanConfirmation from '../../../posts/post/DeleteWithBanConfirmation';
 import postMessages from '../../../posts/post/messages';
+import { getAuthorRoles } from '../../../utils';
 import {
   selectCommentOrResponseById,
 } from '../../data/selectors';
@@ -42,10 +43,11 @@ const Reply = ({ responseId }) => {
   timeago.register('time-locale', timeLocale);
   const commentData = useSelector(selectCommentOrResponseById(responseId));
   const {
-    id, abuseFlagged, author, authorLabel, endorsed, lastEdit, closed, closedBy,
+    id, abuseFlagged, author, authorLabel: rawAuthorLabel, authorLabels, endorsed, lastEdit, closed, closedBy,
     closeReason, createdAt, threadId, parentId, rawBody, renderedBody, editByLabel,
     closedByLabel, isDeleted, deletedBy, deletedByLabel, is_spam: isSpam,
   } = commentData;
+  const authorLabel = (authorLabels && authorLabels.length > 0) ? authorLabels : rawAuthorLabel;
   const intl = useIntl();
   const dispatch = useDispatch();
   const { courseId, enableDiscussionBan } = React.useContext(DiscussionContext);
@@ -66,7 +68,8 @@ const Reply = ({ responseId }) => {
   const [isMutingCoursewide, showMuteCourseConfirmation, hideMuteCourseConfirmation] = useToggle(false);
   const [isUnmutingPersonal, showUnmutePersonalConfirmation, hideUnmutePersonalConfirmation] = useToggle(false);
   const [isUnmutingCoursewide, showUnmuteCourseConfirmation, hideUnmuteCourseConfirmation] = useToggle(false);
-  const colorClass = AvatarOutlineAndLabelColors[authorLabel];
+  const firstRole = getAuthorRoles(authorLabel)[0];
+  const colorClass = AvatarOutlineAndLabelColors[firstRole];
   const isSpamFlagged = isSpam || false;
   const hasAnyAlert = useAlertBannerVisible({
     author,

--- a/src/discussions/post-comments/data/__factories__/comments.factory.js
+++ b/src/discussions/post-comments/data/__factories__/comments.factory.js
@@ -16,6 +16,7 @@ Factory.define('comment')
     author: 'edx',
     author_id: '1',
     author_label: 'Staff',
+    author_labels: ['Staff'],
     can_delete: true,
     created_at: () => (new Date()).toISOString(),
     updated_at: () => (new Date()).toISOString(),

--- a/src/discussions/posts/data/__factories__/threads.factory.js
+++ b/src/discussions/posts/data/__factories__/threads.factory.js
@@ -31,6 +31,7 @@ Factory.define('thread')
     author: 'test_user',
     author_id: '1',
     author_label: null,
+    author_labels: null,
     abuse_flagged: false,
     can_delete: true,
     voted: false,

--- a/src/discussions/posts/post/Post.jsx
+++ b/src/discussions/posts/post/Post.jsx
@@ -36,7 +36,7 @@ import {
 import { muteUserThunk, unmuteUserThunk } from '../../data/thunks';
 import discussionMessages from '../../messages';
 import { selectTopic } from '../../topics/data/selectors';
-import { truncatePath } from '../../utils';
+import { getAuthorRoles, truncatePath } from '../../utils';
 import { selectThread } from '../data/selectors';
 import {
   fetchThread,
@@ -73,10 +73,38 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
 
   const threadData = useSelector(selectThread(postId));
   const {
-    topicId, abuseFlagged, closed, pinned, voted, hasEndorsed, following, closedBy, voteCount, groupId, groupName,
-    closeReason, authorLabel, type: postType, author, title, createdAt, renderedBody, lastEdit, editByLabel,
-    closedByLabel, users: postUsers, isDeleted, deletedBy, deletedByLabel, is_spam: isSpam,
+    topicId,
+    abuseFlagged,
+    closed,
+    pinned,
+    voted,
+    hasEndorsed,
+    following,
+    closedBy,
+    voteCount,
+    groupId,
+    groupName,
+    closeReason,
+    authorLabel: rawAuthorLabel,
+    authorLabels,
+    type: postType,
+    author,
+    title,
+    createdAt,
+    renderedBody,
+    lastEdit,
+    editByLabel,
+    closedByLabel,
+    users: postUsers,
+    isDeleted,
+    deletedBy,
+    deletedByLabel,
+    is_spam: isSpam,
   } = threadData;
+
+  // Prefer the new authorLabels array when available; fall back to the legacy string.
+  // This keeps a single variable flowing through the entire component tree.
+  const authorLabel = (authorLabels && authorLabels.length > 0) ? authorLabels : rawAuthorLabel;
 
   const intl = useIntl();
   const location = useLocation();
@@ -98,18 +126,29 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
   // Compute shouldShowBanOption per authority table
   const userIsAdmin = (userRoles || []).includes('Administrator');
   const userIsModerator = (userRoles || []).includes('Moderator');
-  const userIsDiscussionAdmin = (userRoles || []).includes('Discussion Admin');
-  const userHasDiscussionRole = userIsAdmin || userIsModerator || userIsDiscussionAdmin;
-  const targetIsStaffBadge = authorLabel === 'Staff';
-  const targetIsDiscussionModerator = authorLabel === 'Moderator';
-  const targetIsDiscussionAdmin = authorLabel === 'Discussion Admin';
+  const userHasDiscussionRole = userIsAdmin || userIsModerator;
+
+  // Check target user's role badges (authorLabel can be comma-separated for multi-role users)
+  const targetRoles = getAuthorRoles(authorLabel);
+
+  const targetIsGlobalStaff = targetRoles.includes('Global Staff')
+    || targetRoles.includes('Staff');
+
+  const targetIsDiscussionAdmin = targetRoles.includes('Administrator');
+
+  const targetIsDiscussionModerator = targetRoles.includes('Moderator');
+
+  const targetHasPrivilegedRole = targetIsGlobalStaff
+    || targetIsDiscussionAdmin
+    || targetIsDiscussionModerator;
+
   let shouldShowBanOption = true;
 
-  // Global Staff without discussion role cannot ban  Moderator
+  // Global Staff without discussion role cannot ban privileged users
   if (
     isGlobalStaff
     && !userHasDiscussionRole
-    && (targetIsStaffBadge || targetIsDiscussionModerator || targetIsDiscussionAdmin)
+    && targetHasPrivilegedRole
   ) {
     shouldShowBanOption = false;
   }
@@ -117,10 +156,11 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
   if (userIsModerator && !userIsAdmin && (targetIsDiscussionModerator || targetIsDiscussionAdmin)) {
     shouldShowBanOption = false;
   }
-  // Discussion Admin cannot ban another Admin or Moderator
-  if (userIsDiscussionAdmin && (targetIsDiscussionAdmin || targetIsDiscussionModerator)) {
+  // Discussion Admin cannot ban another Admin
+  if (userIsAdmin && targetIsDiscussionAdmin) {
     shouldShowBanOption = false;
   }
+
   const shouldShowEmailConfirmation = useSelector(selectShouldShowEmailConfirmation);
   const enableDiscussionBan = useSelector(state => state.config.enableDiscussionBan);
   const contentCreationRateLimited = useSelector(selectContentCreationRateLimited);
@@ -629,15 +669,15 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         isUserBanned={isUserBanned}
       />
       {
-    isDeleted && deletedBy && (
-      <DeletedByBanner
-        deletedBy={deletedBy}
-        deletedByLabel={deletedByLabel}
-        message={intl.formatMessage(messages.deletedBy)}
-        postData={threadData}
-      />
-    )
-  }
+        isDeleted && deletedBy && (
+          <DeletedByBanner
+            deletedBy={deletedBy}
+            deletedByLabel={deletedByLabel}
+            message={intl.formatMessage(messages.deletedBy)}
+            postData={threadData}
+          />
+        )
+      }
       <AlertBanner
         author={author}
         abuseFlagged={abuseFlagged}
@@ -667,48 +707,48 @@ const Post = ({ handleAddResponseButton, openRestrictionDialogue }) => {
         <HTMLLoader htmlNode={renderedBody} componentId="post" cssClassName="html-loader w-100" testId={postId} />
       </div>
       {
-    (topicContext || topic) && (
-      <div
-        className={classNames('mt-14px font-style', { 'w-100': enableInContextSidebar, 'mb-1': !displayPostFooter })}
-        style={{ lineHeight: '20px' }}
-      >
-        <span className="text-gray-500" style={{ lineHeight: '20px' }}>
-          {intl.formatMessage(messages.relatedTo)}{' '}
-        </span>
-        <Hyperlink
-          target="_top"
-          destination={topicContext ? (
-            topicContext.unitLink
-          ) : (
-            `${getConfig().BASE_URL}/${courseId}/topics/${topicId}`
-          )}
-        >
-          {(topicContext && !topic) ? (
-            <span>
-              {topicContext.chapterName} / {topicContext.verticalName} / {topicContext.unitName}
+        (topicContext || topic) && (
+          <div
+            className={classNames('mt-14px font-style', { 'w-100': enableInContextSidebar, 'mb-1': !displayPostFooter })}
+            style={{ lineHeight: '20px' }}
+          >
+            <span className="text-gray-500" style={{ lineHeight: '20px' }}>
+              {intl.formatMessage(messages.relatedTo)}{' '}
             </span>
-          ) : (
-            getTopicInfo(topic)
-          )}
-        </Hyperlink>
-      </div>
-    )
-  }
+            <Hyperlink
+              target="_top"
+              destination={topicContext ? (
+                topicContext.unitLink
+              ) : (
+                `${getConfig().BASE_URL}/${courseId}/topics/${topicId}`
+              )}
+            >
+              {(topicContext && !topic) ? (
+                <span>
+                  {topicContext.chapterName} / {topicContext.verticalName} / {topicContext.unitName}
+                </span>
+              ) : (
+                getTopicInfo(topic)
+              )}
+            </Hyperlink>
+          </div>
+        )
+      }
       {
-    displayPostFooter && (
-      <PostFooter
-        id={postId}
-        voteCount={voteCount}
-        voted={voted}
-        following={following}
-        groupId={toString(groupId)}
-        groupName={groupName}
-        closed={closed}
-        userHasModerationPrivileges={userHasModerationPrivileges}
-        isUserBanned={isUserBanned}
-      />
-    )
-  }
+        displayPostFooter && (
+          <PostFooter
+            id={postId}
+            voteCount={voteCount}
+            voted={voted}
+            following={following}
+            groupId={toString(groupId)}
+            groupName={groupName}
+            closed={closed}
+            userHasModerationPrivileges={userHasModerationPrivileges}
+            isUserBanned={isUserBanned}
+          />
+        )
+      }
       <ClosePostReasonModal
         isOpen={isClosing}
         onCancel={hideModal}

--- a/src/discussions/posts/post/Post.test.jsx
+++ b/src/discussions/posts/post/Post.test.jsx
@@ -65,6 +65,7 @@ jest.mock('../../data/selectors', () => ({
 }));
 
 jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
   useActions: jest.fn(() => []),
 }));
 

--- a/src/discussions/posts/post/PostHeader.jsx
+++ b/src/discussions/posts/post/PostHeader.jsx
@@ -12,13 +12,15 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { AvatarOutlineAndLabelColors, ThreadType } from '../../../data/constants';
 import { AuthorLabel } from '../../common';
 import { useAlertBannerVisible } from '../../data/hooks';
+import { getAuthorRoles } from '../../utils';
 import { selectAuthorAvatar } from '../data/selectors';
 import messages from './messages';
 
 export const PostAvatar = React.memo(({
   author, postType, authorLabel, fromPostLink, read, postUsers,
 }) => {
-  const outlineColor = AvatarOutlineAndLabelColors[authorLabel];
+  const firstRole = getAuthorRoles(authorLabel)[0];
+  const outlineColor = AvatarOutlineAndLabelColors[firstRole];
   const authorAvatars = useSelector(selectAuthorAvatar(author));
 
   const avatarSize = useMemo(() => {
@@ -77,7 +79,7 @@ export const PostAvatar = React.memo(({
 PostAvatar.propTypes = {
   author: PropTypes.string.isRequired,
   postType: PropTypes.string.isRequired,
-  authorLabel: PropTypes.string,
+  authorLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   fromPostLink: PropTypes.bool,
   read: PropTypes.bool,
   postUsers: PropTypes.shape({}).isRequired,
@@ -105,7 +107,8 @@ const PostHeader = ({
 }) => {
   const intl = useIntl();
   const showAnsweredBadge = preview && hasEndorsed && postType === ThreadType.QUESTION;
-  const authorLabelColor = AvatarOutlineAndLabelColors[authorLabel];
+  const firstRole = getAuthorRoles(authorLabel)[0];
+  const authorLabelColor = AvatarOutlineAndLabelColors[firstRole];
   const hasAnyAlert = useAlertBannerVisible({
     author, abuseFlagged, lastEdit, closed,
   });
@@ -155,7 +158,7 @@ PostHeader.propTypes = {
   preview: PropTypes.bool,
   hasEndorsed: PropTypes.bool.isRequired,
   postType: PropTypes.string.isRequired,
-  authorLabel: PropTypes.string,
+  authorLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
   author: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,

--- a/src/discussions/posts/post/PostLink.jsx
+++ b/src/discussions/posts/post/PostLink.jsx
@@ -12,7 +12,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { AvatarOutlineAndLabelColors, Routes, ThreadType } from '../../../data/constants';
 import AuthorLabel from '../../common/AuthorLabel';
 import DiscussionContext from '../../common/context';
-import { discussionsPath, isPostPreviewAvailable } from '../../utils';
+import { discussionsPath, getAuthorRoles, isPostPreviewAvailable } from '../../utils';
 import { selectThread } from '../data/selectors';
 import messages from './messages';
 import { PostAvatar } from './PostHeader';
@@ -35,10 +35,33 @@ const PostLink = ({
   } = useContext(DiscussionContext);
   const threadData = useSelector(selectThread(postId));
   const {
-    topicId, hasEndorsed, type, author, authorLabel, abuseFlagged, abuseFlaggedCount, read, commentCount,
-    unreadCommentCount, id, pinned, previewBody, title, voted, voteCount, following, groupId, groupName, createdAt,
-    users: postUsers, isDeleted, threadTitle, commentThreadId,
+    topicId,
+    hasEndorsed,
+    type,
+    author,
+    authorLabel: rawAuthorLabel,
+    authorLabels,
+    abuseFlagged,
+    abuseFlaggedCount,
+    read,
+    commentCount,
+    unreadCommentCount,
+    id,
+    pinned,
+    previewBody,
+    title,
+    voted,
+    voteCount,
+    following,
+    groupId,
+    groupName,
+    createdAt,
+    users: postUsers,
+    isDeleted,
+    threadTitle,
+    commentThreadId,
   } = threadData;
+  const authorLabel = (authorLabels && authorLabels.length > 0) ? authorLabels : rawAuthorLabel;
 
   // Get the type label to display
   const getTypeLabel = () => {
@@ -75,7 +98,8 @@ const PostLink = ({
     learnerUsername,
   })();
   const showAnsweredBadge = hasEndorsed && type === ThreadType.QUESTION;
-  const authorLabelColor = AvatarOutlineAndLabelColors[authorLabel];
+  const firstRole = getAuthorRoles(authorLabel)[0];
+  const authorLabelColor = AvatarOutlineAndLabelColors[firstRole];
   const canSeeReportedBadge = !!(abuseFlagged || abuseFlaggedCount);
   const isPostRead = read || (!read && commentCount !== unreadCommentCount);
   const shouldUseSingleLineAuthorRole = ['learners', 'posts', 'my-posts'].includes(page);

--- a/src/discussions/posts/post/PostLink.test.jsx
+++ b/src/discussions/posts/post/PostLink.test.jsx
@@ -158,7 +158,9 @@ describe('Post username', () => {
       const authorName = screen.getByRole('heading', { name: 'staff-user' });
       const singleLineRow = authorName.closest('div.d-flex.align-items-center.flex-nowrap');
       expect(singleLineRow).toBeInTheDocument();
-      expect(within(singleLineRow).getByText('Staff')).toBeInTheDocument();
+      expect(
+        within(singleLineRow).getByText((content) => content.includes('Global Staff')),
+      ).toBeInTheDocument();
     },
   );
 });

--- a/src/discussions/utils.js
+++ b/src/discussions/utils.js
@@ -32,6 +32,27 @@ import messages from './messages';
  */
 export const getHttpErrorStatus = error => error?.customAttributes?.httpErrorStatus ?? error?.response?.status;
 
+export function getAuthorRoles(authorLabel) {
+  if (Array.isArray(authorLabel)) {
+    return authorLabel
+      .map(role => (typeof role === 'string' ? role.trim() : ''))
+      .filter(Boolean);
+  }
+
+  if (typeof authorLabel === 'string') {
+    return authorLabel
+      .split(',')
+      .map(role => role.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+export function getAuthorLabelText(authorLabel) {
+  return getAuthorRoles(authorLabel).join(', ');
+}
+
 /**
  * Return true if a field has been modified and is no longer valid
  * @param {string} field Name of field
@@ -401,16 +422,36 @@ export function useActions(contentType, id, hasModerationPrivileges) {
     // Only Global Staff, Discussion Moderators, and Group TAs can mute users
     // Course Staff/Admin are excluded
     if (isGlobalStaff || hasDiscussionModeratorPrivileges || isUserGroupTA) {
-      // Check if post author is staff (this would need to come from post data)
-      // For now, assume non-staff authors can be muted by privileged users
-      return !baseContent.authorLabel
-        || !['Staff', 'Moderator', 'Community TA'].includes(baseContent.authorLabel);
+      // Check if post author is staff (handle both new and legacy label formats)
+      // Privileged users (Global Staff, Course Staff, Discussion Admin/Moderator, Community TA) have authorLabel
+      const targetRoles = getAuthorRoles(baseContent.authorLabel);
+      const targetHasRole = targetRoles.includes('Global Staff')
+        || targetRoles.includes('Course Staff')
+        || targetRoles.includes('Course Instructor')
+        || targetRoles.includes('Administrator')
+        || targetRoles.includes('Community TA')
+        || targetRoles.includes('Group Moderator')
+        || targetRoles.includes('Staff') // Legacy
+        || targetRoles.includes('Moderator'); // Legacy
+
+      return !targetHasRole;
     }
 
-    // Learners can mute other learners but not staff
-    if (baseContent.authorLabel
-      && ['Staff', 'Moderator', 'Community TA'].includes(baseContent.authorLabel)) {
-      return false;
+    // Learners cannot mute staff/privileged users
+    if (baseContent.authorLabel) {
+      const targetRoles = getAuthorRoles(baseContent.authorLabel);
+      const targetHasRole = targetRoles.includes('Global Staff')
+        || targetRoles.includes('Course Staff')
+        || targetRoles.includes('Course Instructor')
+        || targetRoles.includes('Administrator')
+        || targetRoles.includes('Community TA')
+        || targetRoles.includes('Group Moderator')
+        || targetRoles.includes('Staff') // Legacy
+        || targetRoles.includes('Moderator'); // Legacy
+
+      if (targetHasRole) {
+        return false;
+      }
     }
 
     return true;
@@ -494,18 +535,27 @@ export function useActions(contentType, id, hasModerationPrivileges) {
     const userIsAdmin = roles.includes('Administrator');
     const userIsModerator = roles.includes('Moderator');
     const userHasDiscussionRole = userIsAdmin || userIsModerator;
-    const targetIsStaffBadge = baseContent?.authorLabel === 'Staff';
-    const targetIsDiscussionModerator = baseContent?.authorLabel === 'Moderator';
+
+    const targetRoles = getAuthorRoles(baseContent?.authorLabel);
+    const targetIsGlobalStaff = targetRoles.includes('Global Staff') || targetRoles.includes('Staff');
+    const targetIsDiscussionAdmin = targetRoles.includes('Administrator');
+    const targetIsDiscussionModerator = targetRoles.includes('Moderator');
+    const targetHasPrivilegedRole = targetIsGlobalStaff || targetIsDiscussionAdmin || targetIsDiscussionModerator;
 
     let shouldShowBanOption = true;
 
-    // Global Staff (no discussion role) cannot ban users with Staff or Moderator badges
-    if (isGlobalStaff && !userHasDiscussionRole && (targetIsStaffBadge || targetIsDiscussionModerator)) {
+    // Global Staff (no discussion role) cannot ban users with privileged roles
+    if (isGlobalStaff && !userHasDiscussionRole && targetHasPrivilegedRole) {
       shouldShowBanOption = false;
     }
 
-    // Discussion Moderator cannot ban another Discussion Moderator
-    if (userIsModerator && !userIsAdmin && targetIsDiscussionModerator) {
+    // Discussion Moderator cannot ban Discussion Admin or another Discussion Moderator
+    if (userIsModerator && !userIsAdmin && (targetIsDiscussionAdmin || targetIsDiscussionModerator)) {
+      shouldShowBanOption = false;
+    }
+
+    // Discussion Admin cannot ban another Discussion Admin
+    if (userIsAdmin && targetIsDiscussionAdmin) {
       shouldShowBanOption = false;
     }
 
@@ -779,6 +829,31 @@ export function truncatePath(path) {
 
 export function getAuthorLabel(intl, authorLabel) {
   const authorLabelMappings = {
+    'Global Staff': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelStaff),
+    },
+    'Course Staff': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelCourseStaff),
+    },
+    'Course Instructor': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelCourseInstructor),
+    },
+    Administrator: {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelAdministrator),
+    },
+    'Community TA': {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelTA),
+    },
+    'Group Moderator': {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelGroupModerator),
+    },
+    // Legacy mappings for backward compatibility
     Staff: {
       icon: Institution,
       authorLabelMessage: intl.formatMessage(messages.authorLabelStaff),
@@ -787,13 +862,78 @@ export function getAuthorLabel(intl, authorLabel) {
       icon: School,
       authorLabelMessage: intl.formatMessage(messages.authorLabelModerator),
     },
+  };
+
+  if (!authorLabel) {
+    return {};
+  }
+
+  // Handle array or comma-separated roles: display the first matching role
+  const roles = getAuthorRoles(authorLabel);
+  for (const role of roles) {
+    if (authorLabelMappings[role]) {
+      return authorLabelMappings[role];
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Returns an array of all matched role label entries for a comma-separated authorLabel string.
+ * Each entry contains { icon, authorLabelMessage, role }.
+ * Unrecognized roles are skipped. Returns an empty array if authorLabel is falsy.
+ * This function does NOT replace getAuthorLabel — it is additive for multi-role display.
+ *
+ * @param {Object} intl - react-intl intl object
+ * @param {string} authorLabel - comma-separated role string from the API
+ * @returns {Array<{icon: React.Component, authorLabelMessage: string, role: string}>}
+ */
+export function getAuthorLabels(intl, authorLabel) {
+  const authorLabelMappings = {
+    'Global Staff': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelStaff),
+    },
+    'Course Staff': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelCourseStaff),
+    },
+    'Course Instructor': {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelCourseInstructor),
+    },
+    Administrator: {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelAdministrator),
+    },
     'Community TA': {
       icon: School,
       authorLabelMessage: intl.formatMessage(messages.authorLabelTA),
     },
+    'Group Moderator': {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelGroupModerator),
+    },
+    // Legacy mappings for backward compatibility
+    Staff: {
+      icon: Institution,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelStaff),
+    },
+    Moderator: {
+      icon: School,
+      authorLabelMessage: intl.formatMessage(messages.authorLabelModerator),
+    },
   };
 
-  return authorLabelMappings[authorLabel] || {};
+  if (!authorLabel) {
+    return [];
+  }
+
+  const roles = getAuthorRoles(authorLabel);
+  return roles
+    .filter(role => Boolean(authorLabelMappings[role]))
+    .map(role => ({ ...authorLabelMappings[role], role }));
 }
 
 export const extractContent = (content) => {

--- a/src/index.scss
+++ b/src/index.scss
@@ -695,7 +695,19 @@ code {
 
 .author-name {
   line-height: 1.5;
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+// Prevent role labels from wrapping - keep on single line with ellipsis
+.author-role-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  min-width: 0; // Allow flex items to shrink below content size
 }
 
 .content-unavailable-desktop {


### PR DESCRIPTION
### Description

The discussion role-labeling system currently uses a priority-based role mapping that converts multiple discussion roles into a single display label. During analysis, I found that CourseStaffRole and CourseInstructorRole users are included in the serializer context but are not considered in _get_user_label(), causing some course staff users to appear as regular learners.

### Findings
Discussion roles are mapped as:
Administrator + Moderator → Moderator
Community TA + Group Moderator → Community TA
 - CourseStaffRole and CourseInstructorRole IDs are collected but never used for author label generation.
 - The current implementation supports only three labels: Staff, Moderator, and Community TA.
 - Existing tests confirm that role aggregation into a single label is the intended behavior.
 
### Impact
 - Course staff/instructors without discussion-specific roles may not receive any author label.
 - Multiple assigned roles are collapsed into a single displayed label based on priority.
 
 ### Linked PR
[ edx-platform](https://github.com/edx/edx-platform/pull/329)
 
### Ticket
[Cosmo2-927](https://2u-internal.atlassian.net/browse/COSMO2-927)
