### PR TITLE
fix: inconsistent loading of discussion thread response

### DIFF
--- a/src/discussions/post-comments/comments/CommentsView.jsx
+++ b/src/discussions/post-comments/comments/CommentsView.jsx
@@ -1,12 +1,15 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, {
+  useCallback, useContext, useEffect, useMemo, useRef, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 
 import { Button, Spinner } from '@openedx/paragon';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { ThreadType } from '../../../data/constants';
+import { PostsStatusFilter, ThreadType } from '../../../data/constants';
+import DiscussionContext from '../../common/context';
 import withPostingRestrictions from '../../common/withPostingRestrictions';
 import { useUserPostingEnabled } from '../../data/hooks';
 import {
@@ -16,18 +19,35 @@ import {
 } from '../../data/selectors';
 import { isLastElementOfList } from '../../utils';
 import { usePostComments } from '../data/hooks';
+import {
+  selectCommentSortOrder,
+} from '../data/selectors';
+import { fetchBatchCommentResponses } from '../data/thunks';
 import messages from '../messages';
 import PostCommentsContext from '../postCommentsContext';
 import { Comment, ResponseEditor } from './comment';
 
 const CommentsView = ({ threadType, openRestrictionDialogue }) => {
   const intl = useIntl();
+  const dispatch = useDispatch();
   const [addingResponse, setAddingResponse] = useState(false);
-  const { isClosed } = useContext(PostCommentsContext);
+  const { isClosed, includeMuted: includeMutedFromContext } = useContext(PostCommentsContext);
+  const { learnerUsername } = useContext(DiscussionContext);
   const isUserPrivilegedInPostingRestriction = useUserPostingEnabled();
   const shouldShowEmailConfirmation = useSelector(selectShouldShowEmailConfirmation);
   const contentCreationRateLimited = useSelector(selectContentCreationRateLimited);
   const isUserBanned = useSelector(selectIsUserBanned);
+  const sortedOrder = useSelector(selectCommentSortOrder);
+  const commentsById = useSelector(state => state.comments.commentsById);
+
+  const postFilter = useSelector(state => state.learners?.postFilter);
+  const showDeleted = Boolean(
+    learnerUsername && postFilter?.contentStatus === PostsStatusFilter.DELETED,
+  );
+
+  // Check if any author is muted
+  const personalMutedUsers = useSelector(state => state.learners?.mutedUsers?.personal || []);
+  const courseWideMutedUsers = useSelector(state => state.learners?.mutedUsers?.course || []);
 
   const {
     endorsedCommentsIds,
@@ -36,6 +56,69 @@ const CommentsView = ({ threadType, openRestrictionDialogue }) => {
     isLoading,
     handleLoadMoreResponses,
   } = usePostComments(threadType);
+
+  // Memoize to prevent new array reference on every render
+  const allVisibleResponseIds = useMemo(
+    () => [...endorsedCommentsIds, ...unEndorsedCommentsIds],
+    [endorsedCommentsIds, unEndorsedCommentsIds],
+  );
+
+  // Track which parent IDs we've already fetched to avoid duplicate batch calls
+  const fetchedBatchRef = useRef(null);
+
+  useEffect(() => {
+    if (allVisibleResponseIds.length === 0) {
+      return undefined;
+    }
+
+    const parentIdsWithChildren = allVisibleResponseIds.filter((commentId) => {
+      const comment = commentsById[commentId];
+      return comment && comment.childCount > 0;
+    });
+
+    if (parentIdsWithChildren.length === 0) {
+      return undefined;
+    }
+
+    // Skip if we already fetched for this exact set of parent IDs
+    const batchKey = parentIdsWithChildren.sort().join(',');
+    if (fetchedBatchRef.current === batchKey) {
+      return undefined;
+    }
+    fetchedBatchRef.current = batchKey;
+
+    const abortController = new AbortController();
+
+    // Debounce: wait 50ms for all responses to finish rendering
+    const timer = setTimeout(() => {
+      const authorsOfParents = parentIdsWithChildren.map(id => commentsById[id]?.author).filter(Boolean);
+      const anyAuthorMuted = authorsOfParents.some(
+        author => personalMutedUsers.includes(author) || courseWideMutedUsers.includes(author),
+      );
+      const shouldIncludeMuted = includeMutedFromContext || anyAuthorMuted;
+
+      dispatch(fetchBatchCommentResponses(parentIdsWithChildren, {
+        reverseOrder: sortedOrder,
+        includeMuted: shouldIncludeMuted,
+        showDeleted,
+        signal: abortController.signal,
+      }));
+    }, 50);
+
+    return () => {
+      clearTimeout(timer);
+      abortController.abort();
+      // Reset ref so refetch happens if deps actually change
+      if (fetchedBatchRef.current === batchKey) {
+        fetchedBatchRef.current = null;
+      }
+    };
+  }, [
+    allVisibleResponseIds.join(','),
+    sortedOrder,
+    showDeleted,
+    includeMutedFromContext,
+  ]);
 
   const handleAddResponse = useCallback(() => {
     if (shouldShowEmailConfirmation || contentCreationRateLimited) {
@@ -66,6 +149,7 @@ const CommentsView = ({ threadType, openRestrictionDialogue }) => {
           commentId={commentId}
           key={commentId}
           marginBottom={isLastElementOfList(postCommentsIds, commentId)}
+          skipChildFetch
         />
       ))}
     </div>
@@ -73,54 +157,54 @@ const CommentsView = ({ threadType, openRestrictionDialogue }) => {
 
   return (
     ((hasMorePages && isLoading) || !isLoading) && (
-    <>
-      {endorsedCommentsIds.length > 0 && (
       <>
-        {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
-        {handleComments(endorsedCommentsIds)}
-      </>
-      )}
-      {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
-      {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
-      {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
-      <Button
-        onClick={handleLoadMoreResponses}
-        variant="link"
-        block="true"
-        className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
-        data-testid="load-more-comments"
-      >
-        {intl.formatMessage(messages.loadMoreResponses)}
-      </Button>
-      )}
-      {isLoading && (
-      <div className="mb-2 mt-3 d-flex justify-content-center">
-        <Spinner animation="border" variant="primary" className="spinner-dimensions" />
-      </div>
-      )}
-      {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
-         && !isClosed && !isUserBanned) && (
-         <div className="mx-4">
-           {!addingResponse && (
-           <Button
-             variant="plain"
-             block="true"
-             className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
+        {endorsedCommentsIds.length > 0 && (
+          <>
+            {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
+            {handleComments(endorsedCommentsIds)}
+          </>
+        )}
+        {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
+        {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
+        {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
+          <Button
+            onClick={handleLoadMoreResponses}
+            variant="link"
+            block="true"
+            className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
+            data-testid="load-more-comments"
+          >
+            {intl.formatMessage(messages.loadMoreResponses)}
+          </Button>
+        )}
+        {isLoading && (
+          <div className="mb-2 mt-3 d-flex justify-content-center">
+            <Spinner animation="border" variant="primary" className="spinner-dimensions" />
+          </div>
+        )}
+        {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
+          && !isClosed && !isUserBanned) && (
+            <div className="mx-4">
+              {!addingResponse && (
+                <Button
+                  variant="plain"
+                  block="true"
+                  className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
                     line-height-24 text-primary-500 bg-white"
-             onClick={handleAddResponse}
-             data-testid="add-response"
-           >
-             {intl.formatMessage(messages.addResponse)}
-           </Button>
-           )}
-           <ResponseEditor
-             addWrappingDiv
-             addingResponse={addingResponse}
-             handleCloseEditor={handleCloseResponseEditor}
-           />
-         </div>
-      )}
-    </>
+                  onClick={handleAddResponse}
+                  data-testid="add-response"
+                >
+                  {intl.formatMessage(messages.addResponse)}
+                </Button>
+              )}
+              <ResponseEditor
+                addWrappingDiv
+                addingResponse={addingResponse}
+                handleCloseEditor={handleCloseResponseEditor}
+              />
+            </div>
+        )}
+      </>
     )
   );
 };

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -74,6 +74,7 @@ const Comment = ({
   commentId,
   marginBottom,
   showFullThread = true,
+  skipChildFetch = false,
   openRestrictionDialogue,
 }) => {
   const comment = useSelector(selectCommentOrResponseById(commentId));
@@ -195,16 +196,23 @@ const Comment = ({
   // If isSpam is not provided in the API response, default to false
   const isSpamFlagged = isSpam || false;
   useEffect(() => {
-    // If the comment has a parent comment, it won't have any children, so don't fetch them.
+    // If batch already fetched children from CommentsView, skip individual fetch.
+    if (skipChildFetch) {
+      return undefined;
+    }
     if (hasChildren && showFullThread) {
+      const abortController = new AbortController();
       dispatch(fetchCommentResponses(id, {
         page: 1,
         reverseOrder: sortedOrder,
         includeMuted: shouldIncludeMuted,
         showDeleted,
+        signal: abortController.signal,
       }));
+      return () => { abortController.abort(); };
     }
-  }, [id, sortedOrder, showDeleted, shouldIncludeMuted]);
+    return undefined;
+  }, [id, sortedOrder, showDeleted, shouldIncludeMuted, skipChildFetch]);
 
   const endorseIcons = useMemo(() => (
     actions.find(({ action }) => action === EndorsementStatus.ENDORSED)
@@ -690,12 +698,14 @@ Comment.propTypes = {
   commentId: PropTypes.string.isRequired,
   marginBottom: PropTypes.bool,
   showFullThread: PropTypes.bool,
+  skipChildFetch: PropTypes.bool,
   openRestrictionDialogue: PropTypes.func.isRequired,
 };
 
 Comment.defaultProps = {
   marginBottom: false,
   showFullThread: true,
+  skipChildFetch: false,
 };
 
 export default React.memo(withPostingRestrictions(Comment));

--- a/src/discussions/post-comments/comments/comment/Comment.test.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.test.jsx
@@ -178,12 +178,15 @@ describe('Comment deleted-by banner', () => {
     renderComment({ childCount: 2 }, { showFullThread: true });
 
     await waitFor(() => {
-      expect(fetchCommentResponses).toHaveBeenCalledWith('comment-1', {
-        includeMuted: false,
-        page: 1,
-        reverseOrder: false,
-        showDeleted: true,
-      });
+      expect(fetchCommentResponses).toHaveBeenCalledWith(
+        'comment-1',
+        expect.objectContaining({
+          includeMuted: false,
+          page: 1,
+          reverseOrder: false,
+          showDeleted: true,
+        }),
+      );
     });
   });
 });

--- a/src/discussions/post-comments/data/api.js
+++ b/src/discussions/post-comments/data/api.js
@@ -55,7 +55,7 @@ export const getThreadComments = async (threadId, {
     includeMuted,
   });
 
-  const { data } = await getAuthenticatedHttpClient().get(getCommentsApiUrl(), { params: { ...params, signal } });
+  const { data } = await getAuthenticatedHttpClient().get(getCommentsApiUrl(), { params, signal });
   return data;
 };
 
@@ -70,22 +70,22 @@ export const getCommentResponses = async (commentId, {
   page,
   pageSize,
   reverseOrder,
-  showDeleted = false,
-  enableDiscussionBan = false,
+  signal,
   includeMuted,
+  showDeleted,
+  enableDiscussionBan = false,
 } = {}) => {
   const url = `${getCommentsApiUrl()}${commentId}/`;
-
   const params = snakeCaseObject({
     page,
     pageSize,
     requestedFields: buildRequestedFields(enableDiscussionBan),
-    includeMuted,
     reverseOrder,
+    includeMuted,
     showDeleted,
   });
-
-  const { data } = await getAuthenticatedHttpClient().get(url, { params });
+  const { data } = await getAuthenticatedHttpClient()
+    .get(url, { params, signal });
   return data;
 };
 /**
@@ -164,5 +164,38 @@ export const restoreComment = async (commentId, courseId) => {
     content_id: commentId,
     course_id: courseId,
   });
+  return data;
+};
+
+/**
+ * Fetches child replies for multiple parent response IDs in a single request.
+ * @param {string[]} parentIds - Array of parent comment IDs
+ * @param {Object} options
+ * @param {number} [options.pageSize]
+ * @param {boolean} [options.reverseOrder]
+ * @param {boolean} [options.includeMuted]
+ * @param {boolean} [options.showDeleted]
+ * @param {AbortSignal} [options.signal]
+ * @returns {Promise<Object>} Grouped results keyed by parent ID
+ */
+export const getBatchCommentResponses = async (parentIds, {
+  pageSize,
+  reverseOrder,
+  includeMuted,
+  showDeleted,
+  signal,
+  enableDiscussionBan = false,
+} = {}) => {
+  const url = `${getConfig().LMS_BASE_URL}/api/discussion/v1/batch_responses/`;
+  const params = snakeCaseObject({
+    parentIds: parentIds.join(','),
+    pageSize,
+    requestedFields: buildRequestedFields(enableDiscussionBan),
+    reverseOrder,
+    includeMuted,
+    showDeleted,
+  });
+  const { data } = await getAuthenticatedHttpClient()
+    .get(url, { params, signal });
   return data;
 };

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -26,19 +26,45 @@ const commentsSlice = createSlice({
     draftComments: {},
   },
   reducers: {
-    fetchCommentsRequest: (state) => (
-      {
+    fetchBatchCommentResponsesSuccess: (state, { payload }) => {
+      const allCommentsById = {};
+      const allCommentsInComments = {};
+      const allResponsesPagination = {};
+
+      Object.entries(payload.batchResults).forEach(([parentId, data]) => {
+        Object.assign(allCommentsById, data.commentsById);
+        allCommentsInComments[parentId] = data.commentsInComments[parentId] || [];
+        allResponsesPagination[parentId] = {
+          currentPage: data.page,
+          totalPages: data.pagination.numPages,
+          hasMorePages: Boolean(data.pagination.next),
+        };
+      });
+
+      return {
+        ...state,
+        status: RequestStatus.SUCCESSFUL,
+        commentsById: { ...state.commentsById, ...allCommentsById },
+        commentsInComments: { ...state.commentsInComments, ...allCommentsInComments },
+        responsesPagination: { ...state.responsesPagination, ...allResponsesPagination },
+      };
+    },
+    fetchCommentsRequest: (state, { payload }) => {
+      const isPageOne = Boolean(payload?.threadId);
+      return {
         ...state,
         status: RequestStatus.IN_PROGRESS,
-      }
-    ),
+        ...(isPageOne && {
+          commentsInThreads: { ...state.commentsInThreads, [payload.threadId]: [] },
+          commentsInComments: {},
+          responsesPagination: {},
+        }),
+      };
+    },
     fetchCommentsSuccess: (state, { payload }) => {
       const { threadId, page } = payload;
-
       const newState = { ...state };
-
       newState.status = RequestStatus.SUCCESSFUL;
-
       newState.pagination = {
         ...newState.pagination,
         [threadId]: newState.pagination[threadId] || {},
@@ -47,10 +73,13 @@ const commentsSlice = createSlice({
       if (page === 1) {
         newState.commentsInThreads = {
           ...newState.commentsInThreads,
-          [threadId]: payload.commentsInThreads[threadId] ? [...payload.commentsInThreads[threadId]] : [],
+          [threadId]: payload.commentsInThreads[threadId]
+            ? [...payload.commentsInThreads[threadId]]
+            : [],
         };
       } else {
         newState.commentsInThreads = {
+          ...newState.commentsInThreads,
           [threadId]: [
             ...new Set([
               ...(newState.commentsInThreads[threadId] || []),
@@ -71,7 +100,6 @@ const commentsSlice = createSlice({
       };
 
       newState.commentsById = { ...newState.commentsById, ...payload.commentsById };
-
       return newState;
     },
     fetchCommentsFailed: (state) => (
@@ -290,6 +318,7 @@ const commentsSlice = createSlice({
 });
 
 export const {
+  fetchBatchCommentResponsesSuccess,
   fetchCommentResponsesDenied,
   fetchCommentResponsesFailed,
   fetchCommentResponsesRequest,

--- a/src/discussions/post-comments/data/thunks.js
+++ b/src/discussions/post-comments/data/thunks.js
@@ -6,13 +6,14 @@ import { setContentCreationRateLimited } from '../../data/slices';
 import { updateThreadAbuseFlaggedCount } from '../../posts/data/slices';
 import { getHttpErrorStatus } from '../../utils';
 import {
-  deleteComment, getCommentResponses, getThreadComments, postComment, updateComment,
+  deleteComment, getBatchCommentResponses, getCommentResponses, getThreadComments, postComment, updateComment,
 } from './api';
 import {
   deleteCommentDenied,
   deleteCommentFailed,
   deleteCommentRequest,
   deleteCommentSuccess,
+  fetchBatchCommentResponsesSuccess,
   fetchCommentResponsesDenied,
   fetchCommentResponsesFailed,
   fetchCommentResponsesRequest,
@@ -92,7 +93,7 @@ export function fetchThreadComments(
 ) {
   return async (dispatch, getState) => {
     try {
-      dispatch(fetchCommentsRequest());
+      dispatch(fetchCommentsRequest(page === 1 ? { threadId } : {}));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
       const data = await getThreadComments(threadId, {
         page, reverseOrder, threadType, enableInContextSidebar, showDeleted, enableDiscussionBan, signal, includeMuted,
@@ -114,14 +115,14 @@ export function fetchThreadComments(
 }
 
 export function fetchCommentResponses(commentId, {
-  page = 1, reverseOrder = true, showDeleted = false, includeMuted,
+  page = 1, reverseOrder = true, signal, includeMuted, showDeleted,
 } = {}) {
   return async (dispatch, getState) => {
     try {
       dispatch(fetchCommentResponsesRequest({ commentId }));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
       const data = await getCommentResponses(commentId, {
-        page, reverseOrder, showDeleted, enableDiscussionBan, includeMuted,
+        page, reverseOrder, signal, includeMuted, showDeleted, enableDiscussionBan,
       });
       dispatch(fetchCommentResponsesSuccess({
         ...normaliseComments(camelCaseObject(data)),
@@ -129,10 +130,13 @@ export function fetchCommentResponses(commentId, {
         commentId,
       }));
     } catch (error) {
+      if (error.name === 'AbortError' || error?.code === 'ERR_CANCELED') {
+        return;
+      }
       if (getHttpErrorStatus(error) === 403) {
-        dispatch(fetchCommentResponsesDenied());
+        dispatch(fetchCommentResponsesDenied({ commentId }));
       } else {
-        dispatch(fetchCommentResponsesFailed());
+        dispatch(fetchCommentResponsesFailed({ commentId }));
       }
       logError(error);
     }
@@ -221,6 +225,51 @@ export function performRestoreComment(commentId, courseId) {
     } catch (error) {
       logError(error);
       return { success: false, error: error.message };
+    }
+  };
+}
+
+/**
+ * Fetches child replies for multiple parent response IDs in a single batch request.
+ * Used when a thread loads and multiple responses have children.
+ *
+ * @param {string[]} parentIds - Array of parent comment IDs with children
+ * @param {Object} options
+ */
+export function fetchBatchCommentResponses(parentIds, {
+  reverseOrder = true, signal, includeMuted, showDeleted,
+} = {}) {
+  return async (dispatch, getState) => {
+    try {
+      dispatch(fetchCommentResponsesRequest({ commentId: parentIds[0] }));
+      const enableDiscussionBan = selectEnableDiscussionBan(getState());
+      const data = await getBatchCommentResponses(parentIds, {
+        reverseOrder, signal, includeMuted, showDeleted, enableDiscussionBan,
+      });
+
+      // Normalize each parent's results and build a batchResults map
+      const batchResults = {};
+      Object.entries(data.results).forEach(([parentId, parentData]) => {
+        const normalized = normaliseComments(camelCaseObject({
+          results: parentData.results,
+          pagination: parentData.pagination,
+        }));
+        batchResults[parentId] = {
+          ...normalized,
+          page: normalized.pagination?.currentPage || 1,
+          pagination: normalized.pagination,
+          commentsInComments: normalized.commentsInComments,
+          commentsById: normalized.commentsById,
+        };
+      });
+
+      dispatch(fetchBatchCommentResponsesSuccess({ batchResults }));
+    } catch (error) {
+      if (error.name === 'AbortError' || error?.code === 'ERR_CANCELED') {
+        return;
+      }
+      dispatch(fetchCommentResponsesFailed({}));
+      logError(error);
     }
   };
 }


### PR DESCRIPTION
### Description

Fixes an issue where inline replies within discussion threads could load inconsistently, causing some replies to appear or disappear between page refreshes.

### Root Cause

Response comments were not being retrieved using backend-level pagination. Combined with frontend request race conditions and stale state handling, this could result in inconsistent loading of inline replies, especially in threads with many responses.

As a result, users could see different combinations of replies on successive page refreshes, even though the underlying discussion data was unchanged.

### Changes
#### Backend (edx-platform)
- Updated response comment retrieval to use forum backend pagination APIs (get_comments and get_comments_count).
- Moved response-comment pagination to the forum backend for more reliable and efficient loading.
- Removed unused code related to the previous pagination approach.
#### Frontend (frontend-app-discussions)
- Added request cancellation using AbortController to prevent stale requests from overwriting newer data.
- Cleared stale child-comment state when reloading response comments.

### Linked PR
[edx-platform](https://github.com/edx/edx-platform/pull/356)

### Ticket
[LP-529](https://2u-internal.atlassian.net/browse/LP-529)