### PR TITLE
fix: inconsistent loading of discussion thread response

### DIFF
--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -195,15 +195,18 @@ const Comment = ({
   // If isSpam is not provided in the API response, default to false
   const isSpamFlagged = isSpam || false;
   useEffect(() => {
-    // If the comment has a parent comment, it won't have any children, so don't fetch them.
     if (hasChildren && showFullThread) {
+      const abortController = new AbortController();
       dispatch(fetchCommentResponses(id, {
         page: 1,
         reverseOrder: sortedOrder,
         includeMuted: shouldIncludeMuted,
         showDeleted,
+        signal: abortController.signal,
       }));
+      return () => { abortController.abort(); };
     }
+    return undefined;
   }, [id, sortedOrder, showDeleted, shouldIncludeMuted]);
 
   const endorseIcons = useMemo(() => (

--- a/src/discussions/post-comments/comments/comment/Comment.test.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.test.jsx
@@ -183,6 +183,7 @@ describe('Comment deleted-by banner', () => {
         page: 1,
         reverseOrder: false,
         showDeleted: true,
+        signal: expect.any(AbortSignal),
       });
     });
   });

--- a/src/discussions/post-comments/data/api.js
+++ b/src/discussions/post-comments/data/api.js
@@ -55,7 +55,7 @@ export const getThreadComments = async (threadId, {
     includeMuted,
   });
 
-  const { data } = await getAuthenticatedHttpClient().get(getCommentsApiUrl(), { params: { ...params, signal } });
+  const { data } = await getAuthenticatedHttpClient().get(getCommentsApiUrl(), { params, signal });
   return data;
 };
 
@@ -67,25 +67,18 @@ export const getThreadComments = async (threadId, {
  * @returns {Promise<{}>}
  */
 export const getCommentResponses = async (commentId, {
-  page,
-  pageSize,
-  reverseOrder,
-  showDeleted = false,
-  enableDiscussionBan = false,
-  includeMuted,
+  page, pageSize, reverseOrder, signal, showDeleted, enableDiscussionBan, includeMuted,
 } = {}) => {
   const url = `${getCommentsApiUrl()}${commentId}/`;
-
   const params = snakeCaseObject({
     page,
     pageSize,
     requestedFields: buildRequestedFields(enableDiscussionBan),
-    includeMuted,
     reverseOrder,
     showDeleted,
+    includeMuted,
   });
-
-  const { data } = await getAuthenticatedHttpClient().get(url, { params });
+  const { data } = await getAuthenticatedHttpClient().get(url, { params, signal });
   return data;
 };
 /**

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -26,12 +26,23 @@ const commentsSlice = createSlice({
     draftComments: {},
   },
   reducers: {
-    fetchCommentsRequest: (state) => (
-      {
+    fetchCommentsRequest: (state, { payload } = {}) => {
+      const newState = {
         ...state,
         status: RequestStatus.IN_PROGRESS,
+      };
+
+      if (payload?.threadId && (!payload?.page || payload.page === 1)) {
+        newState.commentsInThreads = {
+          ...state.commentsInThreads,
+          [payload.threadId]: [],
+        };
+        newState.commentsInComments = {};
+        newState.responsesPagination = {};
       }
-    ),
+
+      return newState;
+    },
     fetchCommentsSuccess: (state, { payload }) => {
       const { threadId, page } = payload;
 

--- a/src/discussions/post-comments/data/thunks.js
+++ b/src/discussions/post-comments/data/thunks.js
@@ -92,7 +92,7 @@ export function fetchThreadComments(
 ) {
   return async (dispatch, getState) => {
     try {
-      dispatch(fetchCommentsRequest());
+      dispatch(fetchCommentsRequest({ threadId, page }));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
       const data = await getThreadComments(threadId, {
         page, reverseOrder, threadType, enableInContextSidebar, showDeleted, enableDiscussionBan, signal, includeMuted,
@@ -114,14 +114,14 @@ export function fetchThreadComments(
 }
 
 export function fetchCommentResponses(commentId, {
-  page = 1, reverseOrder = true, showDeleted = false, includeMuted,
+  page = 1, reverseOrder = true, signal, showDeleted = false, includeMuted,
 } = {}) {
   return async (dispatch, getState) => {
     try {
       dispatch(fetchCommentResponsesRequest({ commentId }));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
       const data = await getCommentResponses(commentId, {
-        page, reverseOrder, showDeleted, enableDiscussionBan, includeMuted,
+        page, reverseOrder, signal, showDeleted, enableDiscussionBan, includeMuted,
       });
       dispatch(fetchCommentResponsesSuccess({
         ...normaliseComments(camelCaseObject(data)),
@@ -129,6 +129,9 @@ export function fetchCommentResponses(commentId, {
         commentId,
       }));
     } catch (error) {
+      if (error.name === 'AbortError' || error?.code === 'ERR_CANCELED') {
+        return;
+      }
       if (getHttpErrorStatus(error) === 403) {
         dispatch(fetchCommentResponsesDenied());
       } else {


### PR DESCRIPTION
### Description

Fixes an issue where inline replies within discussion threads could load inconsistently, causing some replies to appear or disappear between page refreshes.

### Root Cause

Response comments were not being retrieved using backend-level pagination. Combined with frontend request race conditions and stale state handling, this could result in inconsistent loading of inline replies, especially in threads with many responses.

As a result, users could see different combinations of replies on successive page refreshes, even though the underlying discussion data was unchanged.

### Changes
#### Backend (edx-platform)
- Updated response comment retrieval to use forum backend pagination APIs (get_comments and get_comments_count).
- Moved response-comment pagination to the forum backend for more reliable and efficient loading.
- Removed unused code related to the previous pagination approach.
#### Frontend (frontend-app-discussions)
- Added request cancellation using AbortController to prevent stale requests from overwriting newer data.
- Cleared stale child-comment state when reloading response comments.

### Linked PR
[edx-platform](https://github.com/edx/edx-platform/pull/368)

### Ticket
[LP-529](https://2u-internal.atlassian.net/browse/LP-529)