### PR TITLE
fix: inconsistent loading of discussion thread response

### DIFF
--- a/src/discussions/post-comments/comments/CommentsView.jsx
+++ b/src/discussions/post-comments/comments/CommentsView.jsx
@@ -69,59 +69,61 @@ const CommentsView = ({ threadType, openRestrictionDialogue }) => {
         />
       ))}
     </div>
-  ), [hasMorePages, isLoading, handleLoadMoreResponses]);
+  ), []);
 
   return (
-    ((hasMorePages && isLoading) || !isLoading) && (
     <>
-      {endorsedCommentsIds.length > 0 && (
+      {(!isLoading || hasMorePages) && (
       <>
-        {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
-        {handleComments(endorsedCommentsIds)}
+        {endorsedCommentsIds.length > 0 && (
+        <>
+          {handleDefinition(messages.endorsedResponseCount, endorsedCommentsIds.length)}
+          {handleComments(endorsedCommentsIds)}
+        </>
+        )}
+        {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
+        {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
+        {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
+        <Button
+          onClick={handleLoadMoreResponses}
+          variant="link"
+          block="true"
+          className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
+          data-testid="load-more-comments"
+        >
+          {intl.formatMessage(messages.loadMoreResponses)}
+        </Button>
+        )}
+        {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
+           && !isClosed && !isUserBanned) && (
+           <div className="mx-4">
+             {!addingResponse && (
+             <Button
+               variant="plain"
+               block="true"
+               className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
+                      line-height-24 text-primary-500 bg-white"
+               onClick={handleAddResponse}
+               data-testid="add-response"
+             >
+               {intl.formatMessage(messages.addResponse)}
+             </Button>
+             )}
+             <ResponseEditor
+               addWrappingDiv
+               addingResponse={addingResponse}
+               handleCloseEditor={handleCloseResponseEditor}
+             />
+           </div>
+        )}
       </>
-      )}
-      {handleDefinition(messages.responseCount, unEndorsedCommentsIds.length)}
-      {unEndorsedCommentsIds.length > 0 && handleComments(unEndorsedCommentsIds)}
-      {hasMorePages && !isLoading && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length) && (
-      <Button
-        onClick={handleLoadMoreResponses}
-        variant="link"
-        block="true"
-        className="px-4 mt-3 border-0 line-height-24 py-0 mb-2 font-style font-weight-500"
-        data-testid="load-more-comments"
-      >
-        {intl.formatMessage(messages.loadMoreResponses)}
-      </Button>
       )}
       {isLoading && (
       <div className="mb-2 mt-3 d-flex justify-content-center">
         <Spinner animation="border" variant="primary" className="spinner-dimensions" />
       </div>
       )}
-      {(isUserPrivilegedInPostingRestriction && (!!unEndorsedCommentsIds.length || !!endorsedCommentsIds.length)
-         && !isClosed && !isUserBanned) && (
-         <div className="mx-4">
-           {!addingResponse && (
-           <Button
-             variant="plain"
-             block="true"
-             className="card mb-4 px-0 border-0 py-10px mt-2 font-style font-weight-500
-                    line-height-24 text-primary-500 bg-white"
-             onClick={handleAddResponse}
-             data-testid="add-response"
-           >
-             {intl.formatMessage(messages.addResponse)}
-           </Button>
-           )}
-           <ResponseEditor
-             addWrappingDiv
-             addingResponse={addingResponse}
-             handleCloseEditor={handleCloseResponseEditor}
-           />
-         </div>
-      )}
     </>
-    )
   );
 };
 

--- a/src/discussions/post-comments/comments/comment/Comment.jsx
+++ b/src/discussions/post-comments/comments/comment/Comment.jsx
@@ -204,7 +204,7 @@ const Comment = ({
         showDeleted,
       }));
     }
-  }, [id, sortedOrder, showDeleted, shouldIncludeMuted]);
+  }, [id, sortedOrder, showDeleted, shouldIncludeMuted, hasChildren, showFullThread, dispatch]);
 
   const endorseIcons = useMemo(() => (
     actions.find(({ action }) => action === EndorsementStatus.ENDORSED)

--- a/src/discussions/post-comments/data/hooks.js
+++ b/src/discussions/post-comments/data/hooks.js
@@ -55,7 +55,11 @@ export function usePostComments(threadType) {
   const { enableInContextSidebar, postId, learnerUsername } = useContext(DiscussionContext);
   const { includeMuted: includeMutedFromContext } = useContext(PostCommentsContext);
   const [isLoading, dispatch] = useDispatchWithState();
-  const comments = useSelector(selectThreadComments(postId, learnerUsername));
+  const commentsSelector = useMemo(
+    () => selectThreadComments(postId, learnerUsername),
+    [postId, learnerUsername],
+  );
+  const comments = useSelector(commentsSelector);
   const reverseOrder = useSelector(selectCommentSortOrder);
   const hasMorePages = useSelector(selectThreadHasMorePages(postId));
   const currentPage = useSelector(selectThreadCurrentPage(postId));
@@ -63,8 +67,8 @@ export function usePostComments(threadType) {
 
   // Check if the post author is muted by the current user
   const thread = useSelector(selectThread(postId));
-  const personalMutedUsers = useSelector(state => state.learners?.mutedUsers?.personal || []);
-  const courseWideMutedUsers = useSelector(state => state.learners?.mutedUsers?.course || []);
+  const personalMutedUsers = useSelector(state => state.learners.mutedUsers.personal);
+  const courseWideMutedUsers = useSelector(state => state.learners.mutedUsers.course);
   const isAuthorMuted = thread?.author
     ? (personalMutedUsers.includes(thread.author) || courseWideMutedUsers.includes(thread.author))
     : false;
@@ -121,15 +125,11 @@ export function usePostComments(threadType) {
 
 export function useCommentsCount(postId) {
   const { learnerUsername } = useContext(DiscussionContext);
-  const discussions = useSelector(selectThreadComments(postId, learnerUsername));
-  const endorsedQuestions = useSelector(selectThreadComments(postId, learnerUsername));
-  const unendorsedQuestions = useSelector(selectThreadComments(postId, learnerUsername));
-
-  const commentsLength = useMemo(() => (
-    [...discussions, ...endorsedQuestions, ...unendorsedQuestions].length
-  ), [discussions, endorsedQuestions, unendorsedQuestions]);
-
-  return commentsLength;
+  const commentsSelector = useMemo(
+    () => selectThreadComments(postId, learnerUsername),
+    [postId, learnerUsername],
+  );
+  return useSelector(commentsSelector).length;
 }
 
 export const useDraftContent = () => {

--- a/src/discussions/post-comments/data/slices.js
+++ b/src/discussions/post-comments/data/slices.js
@@ -51,6 +51,7 @@ const commentsSlice = createSlice({
         };
       } else {
         newState.commentsInThreads = {
+          ...newState.commentsInThreads,
           [threadId]: [
             ...new Set([
               ...(newState.commentsInThreads[threadId] || []),

--- a/src/discussions/post-comments/data/thunks.js
+++ b/src/discussions/post-comments/data/thunks.js
@@ -43,6 +43,8 @@ function normaliseComments(data) {
   const commentsInComments = {};
   const commentsById = {};
   const ids = [];
+  const seenInComments = {};
+  const seenInThreads = {};
   results.forEach(
     comment => {
       const { parentId, threadId, id } = comment;
@@ -50,15 +52,19 @@ function normaliseComments(data) {
       if (parentId) {
         if (!commentsInComments[parentId]) {
           commentsInComments[parentId] = [];
+          seenInComments[parentId] = new Set();
         }
-        if (!commentsInComments[parentId].includes(id)) {
+        if (!seenInComments[parentId].has(id)) {
+          seenInComments[parentId].add(id);
           commentsInComments[parentId].push(id);
         }
       } else {
         if (!commentsInThreads[threadId]) {
           commentsInThreads[threadId] = [];
+          seenInThreads[threadId] = new Set();
         }
-        if (!commentsInThreads[threadId].includes(id)) {
+        if (!seenInThreads[threadId].has(id)) {
+          seenInThreads[threadId].add(id);
           commentsInThreads[threadId].push(id);
         }
       }
@@ -78,6 +84,8 @@ function normaliseComments(data) {
   };
 }
 
+const pendingThreadFetches = new Set();
+
 export function fetchThreadComments(
   threadId,
   {
@@ -91,6 +99,11 @@ export function fetchThreadComments(
   } = {},
 ) {
   return async (dispatch, getState) => {
+    const requestKey = `${threadId}-p${page}-r${reverseOrder}-d${showDeleted}-m${includeMuted}`;
+    if (pendingThreadFetches.has(requestKey)) {
+      return;
+    }
+    pendingThreadFetches.add(requestKey);
     try {
       dispatch(fetchCommentsRequest());
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
@@ -109,14 +122,28 @@ export function fetchThreadComments(
         dispatch(fetchCommentsFailed());
       }
       logError(error);
+    } finally {
+      pendingThreadFetches.delete(requestKey);
     }
   };
 }
+
+/**
+ * Tracks in-flight fetchCommentResponses calls by commentId.
+ * Prevents duplicate parallel requests for the same comment's responses
+ * when multiple re-renders or sort-order changes fire simultaneously.
+ */
+const pendingResponseFetches = new Set();
 
 export function fetchCommentResponses(commentId, {
   page = 1, reverseOrder = true, showDeleted = false, includeMuted,
 } = {}) {
   return async (dispatch, getState) => {
+    const requestKey = `${commentId}-p${page}-r${reverseOrder}-d${showDeleted}-m${includeMuted}`;
+    if (pendingResponseFetches.has(requestKey)) {
+      return;
+    }
+    pendingResponseFetches.add(requestKey);
     try {
       dispatch(fetchCommentResponsesRequest({ commentId }));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
@@ -135,6 +162,8 @@ export function fetchCommentResponses(commentId, {
         dispatch(fetchCommentResponsesFailed());
       }
       logError(error);
+    } finally {
+      pendingResponseFetches.delete(requestKey);
     }
   };
 }

--- a/src/discussions/posts/data/thunks.js
+++ b/src/discussions/posts/data/thunks.js
@@ -67,9 +67,11 @@ export function normaliseThreads(data, topicIds = null) {
   const threadsById = {};
   let avatars = {};
   const ids = [];
+  const seenInTopics = {};
   if (topicIds) {
     topicIds.forEach(topicId => {
       threadsInTopic[topicId] = [];
+      seenInTopics[topicId] = new Set();
     });
   }
   threads.forEach(
@@ -78,8 +80,10 @@ export function normaliseThreads(data, topicIds = null) {
       ids.push(id);
       if (!threadsInTopic[topicId]) {
         threadsInTopic[topicId] = [];
+        seenInTopics[topicId] = new Set();
       }
-      if (!threadsInTopic[topicId].includes(id)) {
+      if (!seenInTopics[topicId].has(id)) {
+        seenInTopics[topicId].add(id);
         threadsInTopic[topicId].push(id);
       }
       // Normalize editableFields to always be an array
@@ -94,6 +98,8 @@ export function normaliseThreads(data, topicIds = null) {
     ids, threadsById, threadsInTopic, avatars, ...normalized,
   };
 }
+
+const pendingThreadsFetches = new Set();
 
 /**
  * Fetches the threads for the course specified va the threadIds.
@@ -155,6 +161,11 @@ export function fetchThreads(courseId, {
     options.isDeleted = true;
   }
   return async (dispatch, getState) => {
+    const requestKey = `${courseId}|${page}|${options.orderBy}|${options.author}|${options.following}|${options.view}|${options.flagged}|${options.threadType}|${options.textSearch}|${options.cohort}|${options.isDeleted}|${options.includeMuted}|${options.countFlagged}|${(options.topicIds || []).join(',')}`;
+    if (pendingThreadsFetches.has(requestKey)) {
+      return;
+    }
+    pendingThreadsFetches.add(requestKey);
     try {
       dispatch(fetchThreadsRequest({ courseId }));
       const enableDiscussionBan = selectEnableDiscussionBan(getState());
@@ -170,6 +181,8 @@ export function fetchThreads(courseId, {
         dispatch(fetchThreadsFailed());
       }
       logError(error);
+    } finally {
+      pendingThreadsFetches.delete(requestKey);
     }
   };
 }


### PR DESCRIPTION
### Description

Fixes an issue where inline replies within discussion threads could load inconsistently, causing some replies to appear or disappear between page refreshes.

### Root Cause

Response comments were not being retrieved using backend-level pagination. Combined with frontend request race conditions and stale state handling, this could result in inconsistent loading of inline replies, especially in threads with many responses.

As a result, users could see different combinations of replies on successive page refreshes, even though the underlying discussion data was unchanged.

### Changes
#### Frontend (frontend-app-discussions)
- Added request cancellation using AbortController to prevent stale requests from overwriting newer data.
- Cleared stale child-comment state when reloading response comments.


### Ticket
[LP-529](https://2u-internal.atlassian.net/browse/LP-529)